### PR TITLE
Fo 2695

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAO.java
@@ -238,7 +238,7 @@ public class AktivitetDAO {
                 "UPDATE IJOBB SET ANSETTELSESFORHOLD = 'Kassert av NAV', ARBEIDSTID = 'Kassert av NAV'",
                 "UPDATE BEHANDLING SET BEHANDLING_STED = 'Kassert av NAV', EFFEKT = 'Kassert av NAV', BEHANDLING_OPPFOLGING = 'Kassert av NAV', BEHANDLING_TYPE = 'Kassert av NAV'",
                 "UPDATE MOTE SET ADRESSE = 'Kassert av NAV', FORBEREDELSER = 'Kassert av NAV', REFERAT = 'Kassert av NAV'",
-                "UPDATE AKTIVITET SET TITTEL = 'Kassert av NAV', AVSLUTTET_KOMMENTAR = 'Kassert av NAV', LENKE = 'Kassert av NAV', BESKRIVELSE = 'Kassert av NAV'"
+                "UPDATE AKTIVITET SET TITTEL = 'Det var skrevet noe feil, og det er nå slettet', AVSLUTTET_KOMMENTAR = 'Kassert av NAV', LENKE = 'Kassert av NAV', BESKRIVELSE = 'Kassert av NAV'"
         )
                 .map((sql) -> sql + " " + whereClause)
                 .mapToInt((sql) -> database.update(sql, aktivitetId))

--- a/src/main/java/no/nav/veilarbaktivitet/ws/consumer/ArenaAktivitetConsumer.java
+++ b/src/main/java/no/nav/veilarbaktivitet/ws/consumer/ArenaAktivitetConsumer.java
@@ -99,6 +99,24 @@ public class ArenaAktivitetConsumer {
 
     private static final String VANLIG_AMO_NAVN = "Arbeidsmarkedsopplæring (AMO)";
     private static final String JOBBKLUBB_NAVN = "Jobbklubb";
+    private static final String GRUPPE_AMO_NAVN = "Gruppe AMO";
+
+
+    private String getTittel(Tiltaksaktivitet tiltaksaktivitet){
+        val erVanligAmo = tiltaksaktivitet.getTiltaksnavn().trim()
+                .equalsIgnoreCase(VANLIG_AMO_NAVN);
+        if (erVanligAmo) {
+            return "AMO-kurs: " + tiltaksaktivitet.getTiltakLokaltNavn();
+        }
+
+        val erGruppeAmo = tiltaksaktivitet.getTiltaksnavn().trim()
+                .equalsIgnoreCase(GRUPPE_AMO_NAVN);
+        if (erGruppeAmo){
+            return "Gruppe AMO: " + tiltaksaktivitet.getTiltakLokaltNavn();
+        }
+
+        return tiltaksaktivitet.getTiltaksnavn();
+    }
 
     private ArenaAktivitetDTO mapTilAktivitet(Tiltaksaktivitet tiltaksaktivitet) {
         val arenaAktivitetDTO = new ArenaAktivitetDTO()
@@ -117,14 +135,10 @@ public class ArenaAktivitetConsumer {
                 .setStatusSistEndret(DateUtils.getDate(tiltaksaktivitet.getStatusSistEndret()))
                 .setOpprettetDato(DateUtils.getDate(tiltaksaktivitet.getStatusSistEndret()));
 
-
         val erVanligAmo = tiltaksaktivitet.getTiltaksnavn().trim()
                 .equalsIgnoreCase(VANLIG_AMO_NAVN);
 
-        val tittel = erVanligAmo ?
-                "AMO-kurs: " + tiltaksaktivitet.getTiltakLokaltNavn() : tiltaksaktivitet.getTiltaksnavn();
-
-        arenaAktivitetDTO.setTittel(tittel);
+        arenaAktivitetDTO.setTittel(getTittel(tiltaksaktivitet));
 
         val erJobbKlubb = tiltaksaktivitet.getTiltaksnavn().trim()
                 .equalsIgnoreCase(JOBBKLUBB_NAVN);

--- a/src/test/java/no/nav/veilarbaktivitet/ws/consumer/ArenaAktivitetConsumerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/ws/consumer/ArenaAktivitetConsumerTest.java
@@ -101,4 +101,19 @@ public class ArenaAktivitetConsumerTest {
         when(arenaResponse.getTiltaksaktivitetListe()).thenReturn(Arrays.asList(tiltak));
         return arenaResponse;
     }
+
+    @Test
+    public void skalViseTiltaksvariantPaaGruppeAMO () throws Exception {
+        TiltakOgAktivitetV1 arena = mock(TiltakOgAktivitetV1.class);
+        ArenaAktivitetConsumer consumer = new ArenaAktivitetConsumer(arena);
+
+        HentTiltakOgAktiviteterForBrukerResponse responsMedNyAktivitet = responsMedTiltak(new Date());
+        responsMedNyAktivitet.getTiltaksaktivitetListe().get(0).setTiltaksnavn("Gruppe AMO");
+
+        when(arena.hentTiltakOgAktiviteterForBruker(any(HentTiltakOgAktiviteterForBrukerRequest.class)))
+                .thenReturn(responsMedNyAktivitet);
+
+        var aktivitet = consumer.hentArenaAktiviteter(Person.fnr("123")).get(0);
+        assertThat(aktivitet.getTittel(), equalTo("Gruppe AMO: " + aktivitet.getTiltakLokaltNavn()));
+    }
 }


### PR DESCRIPTION
Gitt at jeg som bruker eller veileder har fått en dialogmelding eller aktivitet kassert så skal tittel-teksten være

"Det var skrevet noe feil, og det er nå slettet."

(Resten står som i dag med teksten "Kassert av NAV") 