### PR TITLE
Vær mer robust mot arena tregheter

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/config/ApplicationContext.java
+++ b/src/main/java/no/nav/veilarbaktivitet/config/ApplicationContext.java
@@ -90,6 +90,7 @@ public class ApplicationContext {
                 .address(getRequiredProperty(ApplicationContext.VIRKSOMHET_TILTAKOGAKTIVITET_V1_ENDPOINTURL_PROPERTY))
                 .withOutInterceptor(new LoggingOutInterceptor())
                 .configureStsForSubject(stsConfig)
+                .timeout(10_000, 5_000) // sett ned read timeout til 5s, mulig 2s er et bedre tall om arena tregheter fortsatt er et problem
                 .build();
 
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,13 +6,12 @@ management.endpoints.web.base-path=/internal
 management.endpoints.web.exposure.include=prometheus
 management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
-
 # Vi migrerer databasen med flyway manuelt
 spring.flyway.enabled=false
-
 # Vi setter opp kobling til database manuelt
 spring.data.jdbc.repositories.enabled=false
-
+# Prøv å doble antall threads. default 200, for å se om treghet issues mot arena funker bedre nå
+server.tomcat.threads.max=400
 # Application environment
 app.env.aktorregisterUrl=${AKTOERREGISTER_API_V1_URL}
 app.env.openAmRefreshUrl=${VEILARBLOGIN_OPENAM_REFRESH_URL}


### PR DESCRIPTION
Bumper antall tråder og setter ned arena read timeout-en

Når denne prodsettes/testsettes burde grafana boardet følges med på, for å se om appen takler en dobbling av antall tråder med tanke på CPU og minne. Men tror det burde gå helt fint