### PR TITLE
Implementere endepunkt for å sjekke om bruker har tiltak

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/controller/AktivitetsplanController.java
+++ b/src/main/java/no/nav/veilarbaktivitet/controller/AktivitetsplanController.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static no.nav.veilarbaktivitet.domain.AktivitetStatus.AVBRUTT;
+import static no.nav.veilarbaktivitet.domain.AktivitetStatus.FULLFORT;
 
 
 @RestController
@@ -60,6 +62,16 @@ public class AktivitetsplanController {
         return getFnr()
                 .map(appService::hentArenaAktiviteter)
                 .orElseThrow(RuntimeException::new);
+    }
+
+    @GetMapping("/harTiltak")
+    public boolean hentHarTiltak() {
+        return getFnr()
+                .map(appService::hentArenaAktiviteter)
+                .orElseThrow(RuntimeException::new)
+                .stream()
+                .map(ArenaAktivitetDTO::getStatus)
+                .anyMatch(status -> status != AVBRUTT && status != FULLFORT);
     }
 
     @GetMapping("/{id}/versjoner")

--- a/src/main/java/no/nav/veilarbaktivitet/ws/consumer/ArenaAktivitetConsumer.java
+++ b/src/main/java/no/nav/veilarbaktivitet/ws/consumer/ArenaAktivitetConsumer.java
@@ -50,7 +50,7 @@ public class ArenaAktivitetConsumer {
     Date arenaAktivitetFilterDato;
 
     @Autowired
-    ArenaAktivitetConsumer(TiltakOgAktivitetV1 tiltakOgAktivitetV1) {
+    public ArenaAktivitetConsumer(TiltakOgAktivitetV1 tiltakOgAktivitetV1) {
         this.tiltakOgAktivitetV1 = tiltakOgAktivitetV1;
         this.arenaAktivitetFilterDato = parseDato(getOptionalProperty(ARENA_AKTIVITET_DATOFILTER_PROPERTY).orElse(null));
     }

--- a/src/test/java/no/nav/veilarbaktivitet/mock/HentTiltakOgAktiviteterForBrukerResponseMock.java
+++ b/src/test/java/no/nav/veilarbaktivitet/mock/HentTiltakOgAktiviteterForBrukerResponseMock.java
@@ -6,7 +6,7 @@ import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.meldinger.HentTiltakOgAkt
 import java.util.*;
 
 public class HentTiltakOgAktiviteterForBrukerResponseMock extends HentTiltakOgAktiviteterForBrukerResponse {
-    public void setTiltak(Tiltaksaktivitet tiltak) {
+    public void leggTilTiltak(Tiltaksaktivitet tiltak) {
         tiltaksaktivitetListe = new ArrayList<Tiltaksaktivitet>();
         tiltaksaktivitetListe.add(tiltak);
     }

--- a/src/test/java/no/nav/veilarbaktivitet/mock/HentTiltakOgAktiviteterForBrukerResponseMock.java
+++ b/src/test/java/no/nav/veilarbaktivitet/mock/HentTiltakOgAktiviteterForBrukerResponseMock.java
@@ -1,0 +1,13 @@
+package no.nav.veilarbaktivitet.mock;
+
+import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.informasjon.Tiltaksaktivitet;
+import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.meldinger.HentTiltakOgAktiviteterForBrukerResponse;
+
+import java.util.*;
+
+public class HentTiltakOgAktiviteterForBrukerResponseMock extends HentTiltakOgAktiviteterForBrukerResponse {
+    public void setTiltak(Tiltaksaktivitet tiltak) {
+        tiltaksaktivitetListe = new ArrayList<Tiltaksaktivitet>();
+        tiltaksaktivitetListe.add(tiltak);
+    }
+}

--- a/src/test/java/no/nav/veilarbaktivitet/service/TiltakOgAktivitetMock.java
+++ b/src/test/java/no/nav/veilarbaktivitet/service/TiltakOgAktivitetMock.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TiltakOgAktivitetMock implements TiltakOgAktivitetV1  {
 
-    private Tiltaksaktivitet opprettTiltaktivitet(String status, String id) {
+    private static Tiltaksaktivitet opprettTiltaksaktivitet(String status, String id) {
         Tiltaksaktivitet tiltaksaktivitet = new Tiltaksaktivitet();
         Deltakerstatuser ds = new Deltakerstatuser();
         ds.setValue(status);
@@ -25,13 +25,21 @@ public class TiltakOgAktivitetMock implements TiltakOgAktivitetV1  {
         return tiltaksaktivitet;
     }
 
+    public static Tiltaksaktivitet opprettAktivTiltaksaktivitet() {
+        return opprettTiltaksaktivitet("GJENN", "12");
+    }
+
+    public static Tiltaksaktivitet opprettInaktivTiltaksaktivitet() {
+        return opprettTiltaksaktivitet("GJENN_AVB","11");
+    }
+
     @Override
     public HentTiltakOgAktiviteterForBrukerResponse hentTiltakOgAktiviteterForBruker(HentTiltakOgAktiviteterForBrukerRequest hentTiltakOgAktiviteterForBrukerRequest) throws HentTiltakOgAktiviteterForBrukerPersonIkkeFunnet, HentTiltakOgAktiviteterForBrukerSikkerhetsbegrensning, HentTiltakOgAktiviteterForBrukerUgyldigInput {
         HentTiltakOgAktiviteterForBrukerResponseMock tiltakResponseMock = new HentTiltakOgAktiviteterForBrukerResponseMock();
-        Tiltaksaktivitet t1 = opprettTiltaktivitet("GJENN_AVB","11");
+        Tiltaksaktivitet t1 = opprettInaktivTiltaksaktivitet();
         tiltakResponseMock.leggTilTiltak(t1);
 
-        Tiltaksaktivitet t2 = opprettTiltaktivitet("GJENN", "12");
+        Tiltaksaktivitet t2 = opprettAktivTiltaksaktivitet();
         tiltakResponseMock.leggTilTiltak(t2);
 
         return tiltakResponseMock;

--- a/src/test/java/no/nav/veilarbaktivitet/service/TiltakOgAktivitetMock.java
+++ b/src/test/java/no/nav/veilarbaktivitet/service/TiltakOgAktivitetMock.java
@@ -4,8 +4,11 @@ import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.binding.HentTiltakOgAktiv
 import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.binding.HentTiltakOgAktiviteterForBrukerSikkerhetsbegrensning;
 import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.binding.HentTiltakOgAktiviteterForBrukerUgyldigInput;
 import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.binding.TiltakOgAktivitetV1;
+import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.informasjon.Deltakerstatuser;
+import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.informasjon.Tiltaksaktivitet;
 import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.meldinger.HentTiltakOgAktiviteterForBrukerRequest;
 import no.nav.tjeneste.virksomhet.tiltakogaktivitet.v1.meldinger.HentTiltakOgAktiviteterForBrukerResponse;
+import no.nav.veilarbaktivitet.mock.HentTiltakOgAktiviteterForBrukerResponseMock;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,7 +16,16 @@ public class TiltakOgAktivitetMock implements TiltakOgAktivitetV1  {
 
     @Override
     public HentTiltakOgAktiviteterForBrukerResponse hentTiltakOgAktiviteterForBruker(HentTiltakOgAktiviteterForBrukerRequest hentTiltakOgAktiviteterForBrukerRequest) throws HentTiltakOgAktiviteterForBrukerPersonIkkeFunnet, HentTiltakOgAktiviteterForBrukerSikkerhetsbegrensning, HentTiltakOgAktiviteterForBrukerUgyldigInput {
-        return null;
+        HentTiltakOgAktiviteterForBrukerResponseMock tiltak = new HentTiltakOgAktiviteterForBrukerResponseMock();
+        Tiltaksaktivitet t1 = new Tiltaksaktivitet();
+        Deltakerstatuser ds = new Deltakerstatuser();
+        ds.setValue("GJENN_AVB");
+        t1.setTiltaksnavn("Arbeidsmarkedsopplæring (AMO)");
+        t1.setAktivitetId("11");
+        t1.setTiltakLokaltNavn("Arbeidslivskunnskap med praksis og bransjenorsk");
+        t1.setDeltakerStatus(ds);
+        tiltak.setTiltak(t1);
+        return tiltak;
     }
 
     @Override

--- a/src/test/java/no/nav/veilarbaktivitet/service/TiltakOgAktivitetMock.java
+++ b/src/test/java/no/nav/veilarbaktivitet/service/TiltakOgAktivitetMock.java
@@ -14,18 +14,27 @@ import org.springframework.stereotype.Component;
 @Component
 public class TiltakOgAktivitetMock implements TiltakOgAktivitetV1  {
 
+    private Tiltaksaktivitet opprettTiltaktivitet(String status, String id) {
+        Tiltaksaktivitet tiltaksaktivitet = new Tiltaksaktivitet();
+        Deltakerstatuser ds = new Deltakerstatuser();
+        ds.setValue(status);
+        tiltaksaktivitet.setTiltaksnavn("Arbeidsmarkedsopplæring (AMO)");
+        tiltaksaktivitet.setAktivitetId(id);
+        tiltaksaktivitet.setTiltakLokaltNavn("Arbeidslivskunnskap med praksis og bransjenorsk");
+        tiltaksaktivitet.setDeltakerStatus(ds);
+        return tiltaksaktivitet;
+    }
+
     @Override
     public HentTiltakOgAktiviteterForBrukerResponse hentTiltakOgAktiviteterForBruker(HentTiltakOgAktiviteterForBrukerRequest hentTiltakOgAktiviteterForBrukerRequest) throws HentTiltakOgAktiviteterForBrukerPersonIkkeFunnet, HentTiltakOgAktiviteterForBrukerSikkerhetsbegrensning, HentTiltakOgAktiviteterForBrukerUgyldigInput {
-        HentTiltakOgAktiviteterForBrukerResponseMock tiltak = new HentTiltakOgAktiviteterForBrukerResponseMock();
-        Tiltaksaktivitet t1 = new Tiltaksaktivitet();
-        Deltakerstatuser ds = new Deltakerstatuser();
-        ds.setValue("GJENN_AVB");
-        t1.setTiltaksnavn("Arbeidsmarkedsopplæring (AMO)");
-        t1.setAktivitetId("11");
-        t1.setTiltakLokaltNavn("Arbeidslivskunnskap med praksis og bransjenorsk");
-        t1.setDeltakerStatus(ds);
-        tiltak.setTiltak(t1);
-        return tiltak;
+        HentTiltakOgAktiviteterForBrukerResponseMock tiltakResponseMock = new HentTiltakOgAktiviteterForBrukerResponseMock();
+        Tiltaksaktivitet t1 = opprettTiltaktivitet("GJENN_AVB","11");
+        tiltakResponseMock.leggTilTiltak(t1);
+
+        Tiltaksaktivitet t2 = opprettTiltaktivitet("GJENN", "12");
+        tiltakResponseMock.leggTilTiltak(t2);
+
+        return tiltakResponseMock;
     }
 
     @Override


### PR DESCRIPTION
For at veilarbvisittkortfs skal kunne bruke veilarbaktivitet direkte isteden for å gå via veilarboppfolging

https://trello.com/c/wa2fc7wk/42-fix-visitkortet-slik-at-den-kaller-veilarbaktivitet-direkte-i-stedet-for-gjennom-veilarboppfolging