### PR TITLE
 Fikse feil ved uthenting av FHO i arenaaktivitet

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/arena/ArenaController.java
+++ b/src/main/java/no/nav/veilarbaktivitet/arena/ArenaController.java
@@ -25,22 +25,16 @@ public class ArenaController {
 
     @PutMapping("/forhaandsorientering")
     ArenaAktivitetDTO sendForhaandsorientering(@RequestBody Forhaandsorientering forhaandsorientering, @RequestParam String arenaaktivitetId) {
+        if (!authService.erInternBruker()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Må være internbruker");
+        }
 
-        Person person = userInContext.getUserIdent().orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Må være på en bruker"));
-        Person.AktorId aktorId = userInContext.getAktorId(person).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Må være på en bruker"));
-
-        authService.sjekkTilgangOgInternBruker(aktorId.get(), null);
+        Person.Fnr fnr = userInContext.getFnr().orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Finner ikke fnr"));
 
         getInputFeilmelding(forhaandsorientering, arenaaktivitetId)
                 .ifPresent( feilmelding -> {throw new ResponseStatusException(HttpStatus.BAD_REQUEST, feilmelding);});
 
-        Person.Fnr fnr = userInContext.getFnr(person).orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Finner ikke fnr for bruker"));
-
-        try {
-            return arenaService.lagreForhaandsorientering(arenaaktivitetId, aktorId, fnr, forhaandsorientering);
-        } catch (BadRequestException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
-        }
+        return arenaService.lagreForhaandsorientering(arenaaktivitetId, fnr, forhaandsorientering);
     }
 
     @GetMapping("/tiltak")

--- a/src/main/java/no/nav/veilarbaktivitet/arena/ArenaForhaandsorienteringDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/arena/ArenaForhaandsorienteringDAO.java
@@ -5,16 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.veilarbaktivitet.avtaltMedNav.Forhaandsorientering;
 import no.nav.veilarbaktivitet.db.Database;
 import no.nav.veilarbaktivitet.domain.Person;
-import no.nav.veilarbaktivitet.domain.arena.ArenaAktivitetDTO;
 import no.nav.veilarbaktivitet.util.EnumUtils;
 import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Repository
@@ -39,15 +36,9 @@ public class ArenaForhaandsorienteringDAO {
         log.info("opprettet {}", forhaandsorientering);
     }
 
-    List<ArenaForhaandsorienteringData> hentForhaandsorienteringer(List<ArenaAktivitetDTO> aktiviteter) {
-        if (aktiviteter.isEmpty()) { //sql in kan ikke ta inn tomme lister
-            return Collections.emptyList();
-        }
-
-        List<String> aktivitetIder = aktiviteter.stream().map(ArenaAktivitetDTO::getId).collect(Collectors.toList());
-
+    List<ArenaForhaandsorienteringData> hentForhaandsorienteringer(Person.AktorId aktorId) {
         //language=SQL
-        return database.query("SELECT * FROM ARENA_FORHAANDSORIENTERING A WHERE A.arenaaktivitet_id IN (?)", ArenaForhaandsorienteringDAO::mapForhaandsorientering, aktivitetIder);
+        return database.query("SELECT * FROM ARENA_FORHAANDSORIENTERING WHERE aktor_id = ?", ArenaForhaandsorienteringDAO::mapForhaandsorientering, aktorId.get());
     }
 
     private static ArenaForhaandsorienteringData mapForhaandsorientering(ResultSet rs) throws SQLException {

--- a/src/main/java/no/nav/veilarbaktivitet/arena/BadRequestException.java
+++ b/src/main/java/no/nav/veilarbaktivitet/arena/BadRequestException.java
@@ -1,9 +1,0 @@
-package no.nav.veilarbaktivitet.arena;
-
-public class BadRequestException extends Exception {
-    public BadRequestException(String message) {
-        super(message);
-    }
-
-    private BadRequestException() {};
-}

--- a/src/main/java/no/nav/veilarbaktivitet/service/UserInContext.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/UserInContext.java
@@ -13,23 +13,24 @@ public class UserInContext {
     private final HttpServletRequest requestProvider;
     private final AuthService authService;
 
-    public Optional<Person> getUserIdent() {
+    public Optional<Person.Fnr> getFnr() {
         if (authService.erEksternBruker()) {
             return authService.getInnloggetBrukerIdent().map(Person::fnr);
         }
 
-        Optional<Person> fnr = Optional.ofNullable(requestProvider.getParameter("fnr")).map(Person::fnr);
-        Optional<Person> aktorId = Optional.ofNullable(requestProvider.getParameter("aktorId")).map(Person::aktorId);
+        Optional<Person> fnr = Optional
+                .ofNullable(requestProvider.getParameter("fnr"))
+                .map(Person::fnr);
 
-        return fnr.or(() -> aktorId);
-    }
+        Optional<Person> aktorId = Optional
+                .ofNullable(requestProvider.getParameter("aktorId"))
+                .map(Person::aktorId);
 
-    public Optional<Person.Fnr> getFnr() {
-        return getUserIdent()
+        return fnr.or(() -> aktorId)
                 .flatMap(this::getFnr);
     }
 
-    public Optional<Person.Fnr> getFnr(Person person) {
+    private Optional<Person.Fnr> getFnr(Person person) {
         if (person instanceof Person.Fnr) {
             return Optional.of((Person.Fnr)person);
         }
@@ -40,9 +41,4 @@ public class UserInContext {
 
         return Optional.empty();
     }
-
-    public Optional<Person.AktorId> getAktorId(Person person) {
-        return authService.getAktorIdForPersonBrukerService(person);
-    }
-
 }

--- a/src/test/java/no/nav/veilarbaktivitet/arena/ArenaControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/arena/ArenaControllerTest.java
@@ -29,7 +29,7 @@ public class ArenaControllerTest {
 
     private final JdbcTemplate jdbc = LocalH2Database.getDb();
     private final ArenaForhaandsorienteringDAO dao = new ArenaForhaandsorienteringDAO(new Database(jdbc));
-    private final ArenaService service = new ArenaService(consumer, dao);
+    private final ArenaService service = new ArenaService(consumer, dao, authService);
     private final ArenaController controller = new ArenaController(context, authService, service);
 
     private final Person.AktorId aktorid = Person.aktorId("12345678");
@@ -48,11 +48,9 @@ public class ArenaControllerTest {
                 .when(authService)
                 .sjekkTilgangOgInternBruker(aktorid.get(), null);
 
-        Mockito.when(context.getUserIdent()).thenReturn(Optional.of(fnr));
+        Mockito.when(authService.erInternBruker()).thenReturn(true);
+        Mockito.when(authService.getAktorIdForPersonBrukerService(fnr)).thenReturn(Optional.of(aktorid));
         Mockito.when(context.getFnr()).thenReturn(Optional.of(fnr));
-        Mockito.when(context.getFnr(fnr)).thenReturn(Optional.of(fnr));
-        Mockito.when(context.getFnr(aktorid)).thenReturn(Optional.of(fnr));
-        Mockito.when(context.getAktorId(any())).thenReturn(Optional.of(aktorid));
     }
 
     @Test

--- a/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
@@ -89,7 +89,7 @@ public class AktivitetsplanRSTest {
         when(tiltakOgAktivitet.hentTiltakOgAktiviteterForBruker(any())).thenReturn(responseMock);
 
         ArenaAktivitetConsumer arenaAktivitetConsumerAktiv = new ArenaAktivitetConsumer(tiltakOgAktivitet);
-        ArenaService arenaService = new ArenaService(arenaAktivitetConsumerAktiv, new ArenaForhaandsorienteringDAO(database));
+        ArenaService arenaService = new ArenaService(arenaAktivitetConsumerAktiv, new ArenaForhaandsorienteringDAO(database), authService);
         AktivitetAppService aktivitetAppService = new AktivitetAppService(arenaService, authService, aktivitetService, metricService);
         AktivitetsplanController aktivitetsplanController = new AktivitetsplanController(authService, aktivitetAppService, mockHttpServletRequest);
 
@@ -108,7 +108,7 @@ public class AktivitetsplanRSTest {
         when(tiltakOgAktivitet.hentTiltakOgAktiviteterForBruker(any())).thenReturn(responseMock);
 
         ArenaAktivitetConsumer arenaAktivitetConsumerAktiv = new ArenaAktivitetConsumer(tiltakOgAktivitet);
-        ArenaService arenaService = new ArenaService(arenaAktivitetConsumerAktiv, new ArenaForhaandsorienteringDAO(database));
+        ArenaService arenaService = new ArenaService(arenaAktivitetConsumerAktiv, new ArenaForhaandsorienteringDAO(database), authService);
         AktivitetAppService aktivitetAppService = new AktivitetAppService(arenaService, authService, aktivitetService, metricService);
         AktivitetsplanController aktivitetsplanController = new AktivitetsplanController(authService, aktivitetAppService, mockHttpServletRequest);
 


### PR DESCRIPTION
Gjør om til å hente ut forhåndsorienteringer ved hjelp av aktorId for å fikse feil ved uthenting ved hjelp av en liste med aktivitetsIder. 

Har derfor også skrevet om litt slik at controlleren ikke trenger å forholde seg til aktorId. Servicen henter selv ut aktorId når den har behov for det.