### PR TITLE
Vaske bort mulig navident fra api-resultat

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/avtaltMedNav/AvtaltMedNavService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/avtaltMedNav/AvtaltMedNavService.java
@@ -72,7 +72,7 @@ public class AvtaltMedNavService {
 
         metricService.oppdaterAktivitetMetrikk(nyAktivitet, true, nyAktivitet.isAutomatiskOpprettet());
 
-        return AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetDAO.hentAktivitet(aktivitetId).withForhaandsorientering(fho));
+        return AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetDAO.hentAktivitet(aktivitetId).withForhaandsorientering(fho), false);
     }
 
     public AktivitetDTO markerSomLest(Forhaandsorientering fho, Person innloggetBruker) {
@@ -96,7 +96,7 @@ public class AvtaltMedNavService {
         metricService.oppdaterAktivitetMetrikk(aktivitet, true, aktivitet.isAutomatiskOpprettet());
         meterRegistry.counter(AVTALT_MED_NAV_COUNTER, FORHAANDSORIENTERING_TYPE_LABEL, fho.getType().name(), AKTIVITET_TYPE_LABEL, aktivitet.getAktivitetType().name()).increment();
 
-        return AktivitetDTOMapper.mapTilAktivitetDTO(nyAktivitet);
+        return AktivitetDTOMapper.mapTilAktivitetDTO(nyAktivitet, true);
     }
 
     public Forhaandsorientering hentFhoForAktivitet(long aktivitetId) {

--- a/src/main/java/no/nav/veilarbaktivitet/controller/AktivitetsplanController.java
+++ b/src/main/java/no/nav/veilarbaktivitet/controller/AktivitetsplanController.java
@@ -31,10 +31,11 @@ public class AktivitetsplanController {
 
     @GetMapping
     public AktivitetsplanDTO hentAktivitetsplan() {
+        boolean erEksternBruker = authService.erEksternBruker();
         val aktiviter = appService
                 .hentAktiviteterForIdent(getContextUserIdent())
                 .stream()
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .collect(Collectors.toList());
 
         return new AktivitetsplanDTO().setAktiviteter(aktiviter);
@@ -42,67 +43,74 @@ public class AktivitetsplanController {
 
     @GetMapping("/{id}")
     public AktivitetDTO hentAktivitet(@PathVariable("id") String aktivitetId) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(appService.hentAktivitet(Long.parseLong(aktivitetId)))
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @GetMapping("/{id}/versjoner")
     public List<AktivitetDTO> hentAktivitetVersjoner(@PathVariable("id") String aktivitetId) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(aktivitetId)
                 .map(Long::parseLong)
                 .map(appService::hentAktivitetVersjoner)
                 .map(aktivitetList -> aktivitetList
                         .stream()
-                        .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                        .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                         .collect(Collectors.toList())
                 ).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping("/ny")
     public AktivitetDTO opprettNyAktivitet(@RequestBody AktivitetDTO aktivitet, @RequestParam(required = false, defaultValue = "false") boolean automatisk) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(aktivitet)
                 .map(AktivitetDataMapper::mapTilAktivitetData)
                 .map(aktivitetData -> aktivitetData.withAutomatiskOpprettet(automatisk))
                 .map(aktivitetData -> appService.opprettNyAktivitet(getContextUserIdent(), aktivitetData))
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .orElseThrow(RuntimeException::new);
     }
 
     @PutMapping("/{id}")
     public AktivitetDTO oppdaterAktivitet(@RequestBody AktivitetDTO aktivitet) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(aktivitet)
                 .map(AktivitetDataMapper::mapTilAktivitetData)
                 .map(appService::oppdaterAktivitet)
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .orElseThrow(RuntimeException::new);
     }
 
     @PutMapping("/{id}/etikett")
     public AktivitetDTO oppdaterEtikett(@RequestBody AktivitetDTO aktivitet) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(aktivitet)
                 .map(AktivitetDataMapper::mapTilAktivitetData)
                 .map(appService::oppdaterEtikett)
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .orElseThrow(RuntimeException::new);
     }
 
 
     @PutMapping("/{id}/status")
     public AktivitetDTO oppdaterStatus(@RequestBody AktivitetDTO aktivitet) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(aktivitet)
                 .map(AktivitetDataMapper::mapTilAktivitetData)
                 .map(appService::oppdaterStatus)
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .orElseThrow(RuntimeException::new);
     }
 
     @PutMapping("/{aktivitetId}/referat")
     public AktivitetDTO oppdaterReferat(@RequestBody AktivitetDTO aktivitetDTO) {
+        boolean erEksternBruker = authService.erEksternBruker();
         return Optional.of(aktivitetDTO)
                 .map(AktivitetDataMapper::mapTilAktivitetData)
                 .map(appService::oppdaterReferat)
-                .map(AktivitetDTOMapper::mapTilAktivitetDTO)
+                .map(a -> AktivitetDTOMapper.mapTilAktivitetDTO(a, erEksternBruker))
                 .orElseThrow(RuntimeException::new);
     }
 

--- a/src/main/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapper.java
+++ b/src/main/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapper.java
@@ -11,9 +11,9 @@ public class AktivitetDTOMapper {
 
     private AktivitetDTOMapper() {}
 
-    public static AktivitetDTO mapTilAktivitetDTO(AktivitetData aktivitet) {
+    public static AktivitetDTO mapTilAktivitetDTO(AktivitetData aktivitet, boolean erEkstern) {
 
-        AktivitetDTO aktivitetDTO = new AktivitetDTO()
+        var aktivitetDTO = new AktivitetDTO()
                 .setId(Long.toString(aktivitet.getId()))
                 .setVersjon(Long.toString(aktivitet.getVersjon()))
                 .setTittel(aktivitet.getTittel())
@@ -29,7 +29,7 @@ public class AktivitetDTOMapper {
                 .setLagtInnAv(aktivitet.getLagtInnAv().name())
                 .setOpprettetDato(aktivitet.getOpprettetDato())
                 .setEndretDato(aktivitet.getEndretDato())
-                .setEndretAv(aktivitet.getEndretAv())
+                .setEndretAv(erEkstern ? null : aktivitet.getEndretAv()) // null ut endretAv når bruker er ekstern
                 .setHistorisk(aktivitet.getHistoriskDato() != null)
                 .setTransaksjonsType(aktivitet.getTransaksjonsType());
 
@@ -39,13 +39,12 @@ public class AktivitetDTOMapper {
         FunctionUtils.nullSafe(AktivitetDTOMapper::mapIJobbData).accept(aktivitetDTO, aktivitet.getIJobbAktivitetData());
         FunctionUtils.nullSafe(AktivitetDTOMapper::mapBehandleAktivitetData).accept(aktivitetDTO, aktivitet.getBehandlingAktivitetData());
         FunctionUtils.nullSafe(AktivitetDTOMapper::mapMoteData).accept(aktivitetDTO, aktivitet.getMoteData());
-        FunctionUtils.nullSafe(AktivitetDTOMapper::mapStillingFraNavData).accept(aktivitetDTO, aktivitet.getStillingFraNavData());
+        FunctionUtils.nullSafe(AktivitetDTOMapper::mapStillingFraNavData).accept(aktivitetDTO, aktivitet.getStillingFraNavData(), erEkstern);
         return aktivitetDTO;
     }
 
-    private static void mapStillingFraNavData(AktivitetDTO aktivitetDTO, StillingFraNavData stillingFraNavData) {
-        aktivitetDTO.setStillingFraNavData(stillingFraNavData);
-
+    private static void mapStillingFraNavData(AktivitetDTO aktivitetDTO, StillingFraNavData stillingFraNavData, boolean erEkstern) {
+        aktivitetDTO.setStillingFraNavData(stillingFraNavData.withCvKanDelesAv(erEkstern ? null : stillingFraNavData.getCvKanDelesAv()));
     }
 
     private static void mapMoteData(AktivitetDTO aktivitetDTO, MoteData moteData) {

--- a/src/main/java/no/nav/veilarbaktivitet/util/FunctionUtils.java
+++ b/src/main/java/no/nav/veilarbaktivitet/util/FunctionUtils.java
@@ -27,4 +27,16 @@ public class FunctionUtils {
         };
     }
 
+    public static <A, B, C> TriConsumer<A, B, C> nullSafe(TriConsumer<A, B, C> triConsumer) {
+        return (a, b, c) -> {
+            if (a != null && b != null && c != null) {
+                triConsumer.accept(a, b, c);
+            }
+        };
+    }
+
+    public interface TriConsumer<A, B, C> {
+        void accept(A a, B b, C c);
+    }
+
 }

--- a/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDTOControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDTOControllerTest.java
@@ -159,7 +159,7 @@ public class ForhaandsorienteringDTOControllerTest {
                 .endretAv(ident)
                 .build();
 
-        AktivitetDTO forventetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(forventet);
+        AktivitetDTO forventetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(forventet, false);
 
         assertEquals(markertSomAvtalt.getForhaandsorientering().getTekst(), forventetDTO.getForhaandsorientering().getTekst());
 

--- a/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
@@ -275,7 +275,7 @@ public class AktivitetsplanRSTest {
                 .avsluttetKommentar(nyAvsluttetKommentar)
                 .build();
 
-        this.aktivitet = aktivitetController.oppdaterAktivitet(AktivitetDTOMapper.mapTilAktivitetDTO(nyAktivitet));
+        this.aktivitet = aktivitetController.oppdaterAktivitet(AktivitetDTOMapper.mapTilAktivitetDTO(nyAktivitet, false));
         this.lagredeAktivitetsIder.set(0, Long.parseLong(this.aktivitet.getId()));
     }
 
@@ -292,7 +292,7 @@ public class AktivitetsplanRSTest {
 
     private void da_skal_jeg_kunne_hente_en_aktivitet() {
         assertThat(lagredeAktivitetsIder.get(0).toString(),
-                equalTo(((AktivitetDTO)aktivitetController.hentAktivitet(lagredeAktivitetsIder.get(0).toString())).getId()));
+                equalTo((aktivitetController.hentAktivitet(lagredeAktivitetsIder.get(0).toString())).getId()));
     }
 
     private void da_skal_jeg_denne_aktivteten_ligge_i_min_aktivitetsplan() {

--- a/src/test/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapperTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapperTest.java
@@ -1,0 +1,175 @@
+package no.nav.veilarbaktivitet.mappers;
+
+import no.nav.veilarbaktivitet.avtaltMedNav.Forhaandsorientering;
+import no.nav.veilarbaktivitet.avtaltMedNav.ForhaandsorienteringDTO;
+import no.nav.veilarbaktivitet.avtaltMedNav.Type;
+import no.nav.veilarbaktivitet.domain.*;
+import no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+
+public class AktivitetDTOMapperTest {
+
+    @Test
+    public void skalMappeAktivitetsFelter() {
+        AktivitetData aktivitetData = AktivitetDataTestBuilder.nyAktivitet()
+                .aktivitetType(AktivitetTypeData.MOTE)
+                .build();
+
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetData, false);
+
+        SoftAssertions.assertSoftly( s -> {
+                    s.assertThat(aktivitetDTO.getId()).isEqualTo(aktivitetData.getId().toString());
+                    s.assertThat(aktivitetDTO.getVersjon()).isEqualTo(aktivitetData.getVersjon().toString());
+                    s.assertThat(aktivitetDTO.getTittel()).isEqualTo(aktivitetData.getTittel());
+                    s.assertThat(aktivitetDTO.getTilDato()).isEqualTo(aktivitetData.getTilDato());
+                    s.assertThat(aktivitetDTO.getFraDato()).isEqualTo(aktivitetData.getFraDato());
+                    s.assertThat(aktivitetDTO.getStatus()).isEqualTo(aktivitetData.getStatus());
+                    s.assertThat(aktivitetDTO.getType()).isEqualTo(Helpers.Type.getDTO(aktivitetData.getAktivitetType()));
+                    s.assertThat(aktivitetDTO.getBeskrivelse()).isEqualTo(aktivitetData.getBeskrivelse());
+                    s.assertThat(aktivitetDTO.getLenke()).isEqualTo(aktivitetData.getLenke());
+                    s.assertThat(aktivitetDTO.getAvsluttetKommentar()).isEqualTo(aktivitetData.getAvsluttetKommentar());
+                    s.assertThat(aktivitetDTO.isAvtalt()).isEqualTo(aktivitetData.isAvtalt());
+                    s.assertThat(aktivitetDTO.getLagtInnAv()).isEqualTo(aktivitetData.getLagtInnAv().name());
+                    s.assertThat(aktivitetDTO.getOpprettetDato()).isEqualTo(aktivitetData.getOpprettetDato());
+                    s.assertThat(aktivitetDTO.getEndretDato()).isEqualTo(aktivitetData.getEndretDato());
+                    s.assertThat(aktivitetDTO.getEndretAv()).isEqualTo(aktivitetData.getEndretAv());
+                    if (aktivitetDTO.isHistorisk()) {
+                        s.assertThat(aktivitetData.getHistoriskDato()).isNotNull();
+                    } else {
+                        s.assertThat(aktivitetData.getHistoriskDato()).isNull();
+                    }
+                    s.assertThat(aktivitetDTO.getTransaksjonsType()).isEqualTo(aktivitetData.getTransaksjonsType());
+                    s.assertAll();
+                });
+    }
+
+    @Test
+    public void skalMappeForhaandsorientering() {
+        AktivitetData aktivitetData = AktivitetDataTestBuilder.nyAktivitet()
+                .aktivitetType(AktivitetTypeData.MOTE)
+                .forhaandsorientering(Forhaandsorientering
+                        .builder()
+                        .id("1234")
+                        .type(Type.SEND_FORHAANDSORIENTERING)
+                        .tekst("Forhåndsorientering")
+                        .lestDato(AktivitetDataTestBuilder.nyDato())
+                        .build())
+                .build();
+
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetData, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(Helpers.Type.getDTO(aktivitetData.getAktivitetType()));
+            ForhaandsorienteringDTO mappingResult = aktivitetDTO.getForhaandsorientering();
+            Forhaandsorientering mappingSource = aktivitetData.getForhaandsorientering();
+            s.assertThat(mappingResult).isNotNull();
+            s.assertThat(mappingResult.getId()).isEqualTo(mappingSource.getId());
+            s.assertThat(mappingResult.getType()).isEqualTo(mappingSource.getType());
+            s.assertThat(mappingResult.getTekst()).isEqualTo(mappingSource.getTekst());
+            s.assertThat(mappingResult.getLestDato()).isEqualTo(mappingSource.getLestDato());
+            s.assertAll();
+        });
+
+    }
+
+    @Test
+    public void skalMappeStillingSokData() {
+        AktivitetData nyttStillingssøk = AktivitetDataTestBuilder.nyttStillingssøk();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyttStillingssøk, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.STILLING);
+            s.assertThat(aktivitetDTO.getArbeidsgiver()).isEqualTo(nyttStillingssøk.getStillingsSoekAktivitetData().getArbeidsgiver());
+            s.assertThat(aktivitetDTO.getStillingsTittel()).isEqualTo(nyttStillingssøk.getStillingsSoekAktivitetData().getStillingsTittel());
+            s.assertThat(aktivitetDTO.getArbeidssted()).isEqualTo(nyttStillingssøk.getStillingsSoekAktivitetData().getArbeidssted());
+            s.assertThat(aktivitetDTO.getKontaktperson()).isEqualTo(nyttStillingssøk.getStillingsSoekAktivitetData().getKontaktPerson());
+            s.assertThat(aktivitetDTO.getEtikett()).isEqualTo(Helpers.Etikett.getDTO(nyttStillingssøk.getStillingsSoekAktivitetData().getStillingsoekEtikett()));
+
+            s.assertAll();
+        });
+    }
+
+    @Test
+    public void skalMappeEgenAktivitetData() {
+        AktivitetData nyEgenaktivitet = AktivitetDataTestBuilder.nyEgenaktivitet();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyEgenaktivitet, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.EGEN);
+            s.assertThat(aktivitetDTO.getHensikt()).isEqualTo(nyEgenaktivitet.getEgenAktivitetData().getHensikt());
+            s.assertThat(aktivitetDTO.getOppfolging()).isEqualTo(nyEgenaktivitet.getEgenAktivitetData().getOppfolging());
+            s.assertAll();
+        });
+
+    }
+
+    @Test
+    public void skalMappeSokeAvtaleData() {
+        AktivitetData nySokeAvtaleAktivitet = AktivitetDataTestBuilder.nySokeAvtaleAktivitet();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nySokeAvtaleAktivitet, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.SOKEAVTALE);
+            s.assertThat(aktivitetDTO.getAntallStillingerIUken()).isEqualTo(nySokeAvtaleAktivitet.getSokeAvtaleAktivitetData().antallStillingerIUken);
+            s.assertThat(aktivitetDTO.getAntallStillingerSokes()).isEqualTo(nySokeAvtaleAktivitet.getSokeAvtaleAktivitetData().antallStillingerSokes);
+            s.assertThat(aktivitetDTO.getAvtaleOppfolging()).isEqualTo(nySokeAvtaleAktivitet.getSokeAvtaleAktivitetData().avtaleOppfolging);
+            s.assertAll();
+        });
+    }
+
+    @Test
+    public void skalMappeIJobbData() {
+        AktivitetData nyIJobbAktivitet = AktivitetDataTestBuilder.nyIJobbAktivitet();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyIJobbAktivitet, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.IJOBB);
+            s.assertThat(aktivitetDTO.getJobbStatus()).isEqualTo(Helpers.JobbStatus.getDTO(nyIJobbAktivitet.getIJobbAktivitetData().getJobbStatusType()));
+            s.assertThat(aktivitetDTO.getAnsettelsesforhold()).isEqualTo(nyIJobbAktivitet.getIJobbAktivitetData().getAnsettelsesforhold());
+            s.assertThat(aktivitetDTO.getArbeidstid()).isEqualTo(nyIJobbAktivitet.getIJobbAktivitetData().getArbeidstid());
+            s.assertAll();
+        });
+    }
+
+    @Test
+    public void skalMappeBehandleAktivitetData() {
+        AktivitetData nyBehandlingAktivitet = AktivitetDataTestBuilder.nyBehandlingAktivitet();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyBehandlingAktivitet, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.BEHANDLING);
+            s.assertThat(aktivitetDTO.getBehandlingType()).isEqualTo(nyBehandlingAktivitet.getBehandlingAktivitetData().getBehandlingType());
+            s.assertThat(aktivitetDTO.getBehandlingSted()).isEqualTo(nyBehandlingAktivitet.getBehandlingAktivitetData().getBehandlingSted());
+            s.assertThat(aktivitetDTO.getBehandlingOppfolging()).isEqualTo(nyBehandlingAktivitet.getBehandlingAktivitetData().getBehandlingOppfolging());
+            s.assertThat(aktivitetDTO.getEffekt()).isEqualTo(nyBehandlingAktivitet.getBehandlingAktivitetData().getEffekt());
+            s.assertAll();
+        });
+    }
+
+    @Test
+    public void skalMappeMoteData() {
+        AktivitetData nyMoteAktivitet = AktivitetDataTestBuilder.nyMoteAktivitet();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyMoteAktivitet, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.MOTE);
+            s.assertThat(aktivitetDTO.getAdresse()).isEqualTo(nyMoteAktivitet.getMoteData().getAdresse());
+            s.assertThat(aktivitetDTO.getForberedelser()).isEqualTo(nyMoteAktivitet.getMoteData().getForberedelser());
+            s.assertThat(aktivitetDTO.getKanal()).isEqualTo(nyMoteAktivitet.getMoteData().getKanal());
+            s.assertThat(aktivitetDTO.getReferat()).isEqualTo(nyMoteAktivitet.getMoteData().getReferat());
+            s.assertThat(aktivitetDTO.isErReferatPublisert()).isEqualTo(nyMoteAktivitet.getMoteData().isReferatPublisert());
+            s.assertAll();
+        });
+    }
+
+    @Test
+    public void skalMappeStillingFraNavData() {
+        AktivitetData nyStillingFraNav = AktivitetDataTestBuilder.nyStillingFraNav();
+        AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyStillingFraNav, false);
+        SoftAssertions.assertSoftly( s -> {
+            s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.STILLING_FRA_NAV);
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getKanDeles()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getKanDeles());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesAv()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesAv());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesAvType()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesAvType());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesTidspunkt()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesTidspunkt());
+
+            s.assertAll();
+        });
+    }
+
+}

--- a/src/test/java/no/nav/veilarbaktivitet/mock/TestData.java
+++ b/src/test/java/no/nav/veilarbaktivitet/mock/TestData.java
@@ -6,5 +6,6 @@ public class TestData {
 
     public static final Person.Fnr KJENT_IDENT = Person.fnr("1234");
     public static final Person.AktorId KJENT_AKTOR_ID = Person.aktorId("4321");
+    public static final Person.NavIdent KJENT_SAKSBEHANDLER = Person.navIdent("Z999999");
     public static final String KJENT_KONTORSPERRE_ENHET_ID = "1337";
 }

--- a/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetDataTestBuilder.java
+++ b/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetDataTestBuilder.java
@@ -29,6 +29,8 @@ public class AktivitetDataTestBuilder {
                 .transaksjonsType(AktivitetTransaksjonsType.DETALJER_ENDRET)
                 .lestAvBrukerForsteGang(null)
                 .historiskDato(null)
+                .endretDato(nyDato())
+                .endretAv("Z999999")
                 .malid("2");
     }
 
@@ -57,6 +59,7 @@ public class AktivitetDataTestBuilder {
     public static AktivitetData nyStillingFraNav() {
         return AktivitetDataTestBuilder.nyAktivitet()
                 .aktivitetType(AktivitetTypeData.STILLING_FRA_NAV)
+                .stillingFraNavData(AktivitetTypeDataTesBuilder.nyStillingFraNav())
                 .build();
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
+++ b/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
@@ -19,6 +19,7 @@ public class AktivitetTypeDataTesBuilder {
     public static EgenAktivitetData nyEgenaktivitet() {
         return EgenAktivitetData.builder()
                 .hensikt("nada")
+                .oppfolging("oppfølging")
                 .build();
     }
 
@@ -64,6 +65,15 @@ public class AktivitetTypeDataTesBuilder {
                 .forberedelser("blee")
                 .referat("temp")
                 .referatPublisert(false)
+                .build();
+    }
+
+    public static StillingFraNavData nyStillingFraNav() {
+        return StillingFraNavData.builder()
+                .cvKanDelesAvType(InnsenderData.NAV)
+                .cvKanDelesAv("Z999999")
+                .cvKanDelesTidspunkt(AktivitetDataTestBuilder.nyDato())
+                .kanDeles(Boolean.TRUE)
                 .build();
     }
 }


### PR DESCRIPTION
Enkel maskering av felter som kan inneholde saksbehandlers id.
https://trello.com/c/CBnY0UfV