### PR TITLE
Stopp varsel hvis aktivitet blir avbrutt eller fullført

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.val;
 import no.nav.veilarbaktivitet.avtaltMedNav.AvtaltMedNavService;
-import no.nav.veilarbaktivitet.avtaltMedNav.Forhaandsorientering;
 import no.nav.veilarbaktivitet.db.dao.AktivitetDAO;
 import no.nav.veilarbaktivitet.domain.*;
 import no.nav.veilarbaktivitet.kvp.KvpService;
@@ -71,8 +70,9 @@ public class AktivitetService {
         return aktivitetId;
     }
 
+    @Transactional
     public void oppdaterStatus(AktivitetData originalAktivitet, AktivitetData aktivitet, Person endretAv) {
-        val nyAktivitet = originalAktivitet
+        var nyAktivitet = originalAktivitet
                 .toBuilder()
                 .status(aktivitet.getStatus())
                 .lagtInnAv(endretAv.tilBrukerType())
@@ -82,6 +82,10 @@ public class AktivitetService {
                 .build();
 
         aktivitetDAO.insertAktivitet(nyAktivitet);
+
+        if(nyAktivitet.getStatus() == AktivitetStatus.AVBRUTT || nyAktivitet.getStatus() == AktivitetStatus.FULLFORT){
+            avtaltMedNavService.stoppVarselHvisAktiv(originalAktivitet.getFhoId());
+        }
     }
 
     public void oppdaterEtikett(AktivitetData originalAktivitet, AktivitetData aktivitet, Person endretAv) {

--- a/src/main/java/no/nav/veilarbaktivitet/service/MetricService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/MetricService.java
@@ -38,14 +38,6 @@ public class MetricService {
         metricsClient.report(ev);
     }
 
-    public void oppdatertStatusAvNAV(AktivitetData aktivitetData) {
-        oppdatertStatus(aktivitetData, true);
-    }
-
-    public void oppdatertStatusAvBruker(AktivitetData aktivitetData) {
-        oppdatertStatus(aktivitetData, false);
-    }
-
     public void reportIngenTilgangGrunnetKontorsperre() {
         Event ev = new Event("aktivitet.kontorsperre.ikketilgang");
         metricsClient.report(ev);

--- a/src/main/java/no/nav/veilarbaktivitet/service/MetricService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/MetricService.java
@@ -72,7 +72,7 @@ public class MetricService {
 
     }
 
-    private void oppdatertStatus(AktivitetData aktivitetData, boolean oppdatertAvNAV) {
+    public void oppdatertStatus(AktivitetData aktivitetData, boolean oppdatertAvNAV) {
         String malId = Optional.ofNullable(aktivitetData.getMalid()).orElse("");
         Event ev = new Event("aktivitet.oppdatert.status")
                 .addTagToReport("type", aktivitetData.getAktivitetType().toString())


### PR DESCRIPTION
* Gjør om koden ved endring av aktivitetstatus fordi den var unødvendig komplisert med duplisert kode for veileder/bruker
* Legger inn at varsel skal avsluttes dersom man setter aktivitet til avbrutt/fullført(dette er ikke noe vi har hatt før men noe Håkon og Kari-Anne har blitt enige om tidligere)