### PR TITLE
Ytelse

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/avtaltMedNav/AvtaltMedNavService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/avtaltMedNav/AvtaltMedNavService.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -107,6 +109,11 @@ public class AvtaltMedNavService {
     public Forhaandsorientering hentFHO(String fhoId) {
         if(fhoId == null) return null;
         return fhoDAO.getById(fhoId);
+    }
+
+    public List<Forhaandsorientering> hentFHO(List<String> fhoIder){
+        var fhoIderUtenTomme = fhoIder.stream().filter(x-> x != null && !x.isEmpty()).collect(Collectors.toList());
+        return fhoDAO.getById(fhoIderUtenTomme);
     }
 
     public boolean settVarselFerdig(String forhaandsorienteringId) {

--- a/src/main/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDAO.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -82,9 +83,7 @@ public class ForhaandsorienteringDAO {
 
     public boolean settVarselFerdig(String forhaandsorienteringId) {
         //language=sql
-        var stoppet = 1 == database.update("UPDATE FORHAANDSORIENTERING SET VARSEL_FERDIG = CURRENT_TIMESTAMP WHERE ID = ? AND VARSEL_FERDIG is null", forhaandsorienteringId);
-
-        return stoppet;
+        return 1 == database.update("UPDATE FORHAANDSORIENTERING SET VARSEL_FERDIG = CURRENT_TIMESTAMP WHERE ID = ? AND VARSEL_FERDIG is null", forhaandsorienteringId);
     }
 
     public Forhaandsorientering getById(String id) {
@@ -95,6 +94,14 @@ public class ForhaandsorienteringDAO {
         catch(EmptyResultDataAccessException e) {
             return null;
         }
+    }
+
+    public List<Forhaandsorientering> getById(List<String> ider) {
+        String idString = ider.stream().collect(Collectors.joining("','", "'","'"));
+        //language=sql
+        String sql = String.format("SELECT * FROM FORHAANDSORIENTERING WHERE id IN(%s)",idString);
+
+        return database.query(sql, ForhaandsorienteringDAO::map);
     }
 
     public Forhaandsorientering getFhoForAktivitet(long aktivitetId) {

--- a/src/main/java/no/nav/veilarbaktivitet/db/Database.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/Database.java
@@ -1,6 +1,8 @@
 package no.nav.veilarbaktivitet.db;
+import lombok.Getter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import java.sql.ResultSet;
@@ -12,12 +14,15 @@ import java.util.List;
 import static java.util.Optional.ofNullable;
 
 @Component
+@Getter
 public class Database {
 
-    private JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedJdbcTemplate;
 
     public Database(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        namedJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
     }
 
     public <T> List<T> query(String sql, Mapper<T> mapper, Object... args) {

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
@@ -44,10 +44,7 @@ public class AktivitetService {
     }
 
     public List<AktivitetData> hentAktivitetVersjoner(long id) {
-        return aktivitetDAO.hentAktivitetVersjoner(id)
-                .stream()
-                .map(a -> a.withForhaandsorientering(avtaltMedNavService.hentFHO(a.getFhoId())))
-                .collect(Collectors.toList());
+        return aktivitetDAO.hentAktivitetVersjoner(id);
     }
 
     public long opprettAktivitet(Person.AktorId aktorId, AktivitetData aktivitet, Person endretAvPerson) {

--- a/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDAOTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDAOTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
@@ -146,5 +147,17 @@ public class ForhaandsorienteringDAOTest {
 
         var result = fhoDAO.getById(List.of(fho1.getId(), fho2.getId()));
         Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void getById_ingenIder_returnererTomListe() {
+        var avtalt1 = new AvtaltMedNavDTO().setAktivitetVersjon(new Random().nextLong()).setForhaandsorientering(ForhaandsorienteringDTO.builder().type(Type.SEND_FORHAANDSORIENTERING).tekst("test").build());
+        var avtalt2 = new AvtaltMedNavDTO().setAktivitetVersjon(new Random().nextLong()).setForhaandsorientering(ForhaandsorienteringDTO.builder().type(Type.SEND_FORHAANDSORIENTERING).tekst("test2").build());
+
+         fhoDAO.insert(avtalt1, new Random().nextLong(), AKTOR_ID, "V123", new Date());
+         fhoDAO.insert(avtalt2, new Random().nextLong(), AKTOR_ID, "V123", new Date());
+
+        var result = fhoDAO.getById(Collections.emptyList());
+        Assert.assertEquals(0, result.size());
     }
 }

--- a/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDAOTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDAOTest.java
@@ -1,6 +1,7 @@
 package no.nav.veilarbaktivitet.avtaltMedNav;
 
 import no.nav.veilarbaktivitet.db.Database;
+import no.nav.veilarbaktivitet.db.DbTestUtils;
 import no.nav.veilarbaktivitet.db.dao.AktivitetDAO;
 import no.nav.veilarbaktivitet.domain.Person;
 import no.nav.veilarbaktivitet.domain.arena.ArenaAktivitetDTO;
@@ -9,11 +10,12 @@ import no.nav.veilarbaktivitet.mock.LocalH2Database;
 import no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Random;
-
 import static org.junit.Assert.*;
 
 public class ForhaandsorienteringDAOTest {
@@ -24,6 +26,11 @@ public class ForhaandsorienteringDAOTest {
     private final Database database = new Database(jdbcTemplate);
     private final ForhaandsorienteringDAO fhoDAO = new ForhaandsorienteringDAO(database);
     private final AktivitetDAO aktivitetDAO = new AktivitetDAO(database);
+
+    @AfterEach
+    public void cleanup() {
+        DbTestUtils.cleanupTestDb(jdbcTemplate);
+    }
 
     @Test
     public void insertForAktivitet_oppdatererAlleFelter() {
@@ -127,5 +134,17 @@ public class ForhaandsorienteringDAOTest {
     @Test
     public void getFhoForAktivitet_forhaandsorienteringEksistererIkke_returnererNull() {
         Assert.assertNull(fhoDAO.getFhoForAktivitet(5000L));
+    }
+
+    @Test
+    public void getById_flereIder_returnererAlle() {
+        var avtalt1 = new AvtaltMedNavDTO().setAktivitetVersjon(new Random().nextLong()).setForhaandsorientering(ForhaandsorienteringDTO.builder().type(Type.SEND_FORHAANDSORIENTERING).tekst("test").build());
+        var avtalt2 = new AvtaltMedNavDTO().setAktivitetVersjon(new Random().nextLong()).setForhaandsorientering(ForhaandsorienteringDTO.builder().type(Type.SEND_FORHAANDSORIENTERING).tekst("test2").build());
+
+        var fho1 = fhoDAO.insert(avtalt1, new Random().nextLong(), AKTOR_ID, "V123", new Date());
+        var fho2 = fhoDAO.insert(avtalt2, new Random().nextLong(), AKTOR_ID, "V123", new Date());
+
+        var result = fhoDAO.getById(List.of(fho1.getId(), fho2.getId()));
+        Assert.assertEquals(2, result.size());
     }
 }


### PR DESCRIPTION
For forbedret ytelse:
Henter ut alle relevante fho i en operasjon når man henter aktivitetsplanen, gjør implementasjonen lik som ved uthenting av arenaaktiviteter med fho
Fjerner uthenting av fho ved uthenting av aktivitetsversjoner fordi det er ikke behov for det
