### PR TITLE
Flytter til pto namespace

### DIFF
--- a/nais-q.yaml
+++ b/nais-q.yaml
@@ -2,16 +2,16 @@ kind: Application
 apiVersion: nais.io/v1alpha1
 metadata:
   name: veilarbaktivitet
-  namespace: {{namespace}}
+  namespace: pto
   cluster: dev-fss
   labels:
     team: pto
 spec:
   image: docker.pkg.github.com/navikt/veilarbaktivitet/veilarbaktivitet:{{version}}
   ingresses:
-    - https://veilarbaktivitet-{{namespace}}.nais.preprod.local
-    - https://app-{{namespace}}.adeo.no/veilarbaktivitet
-    - https://app-{{namespace}}.dev.adeo.no/veilarbaktivitet
+    - https://veilarbaktivitet-q1.nais.preprod.local
+    - https://app-q1.adeo.no/veilarbaktivitet
+    - https://app-q1.dev.adeo.no/veilarbaktivitet
   port: 8080
   prometheus:
     enabled: true
@@ -43,13 +43,13 @@ spec:
   vault:
     enabled: true
     paths:
-      - kvPath: /oracle/data/dev/creds/veilarbaktivitet_{{namespace}}-user
+      - kvPath: /oracle/data/dev/creds/veilarbaktivitet_q1-user
         mountPath: /var/run/secrets/nais.io/oracle_creds
       - kvPath: /serviceuser/data/dev/srvveilarbaktivitet
         mountPath: /var/run/secrets/nais.io/service_user
-      - kvPath: /kv/preprod/fss/veilarbaktivitet/{{namespace}}
+      - kvPath: /kv/preprod/fss/veilarbaktivitet/q1
         mountPath: /var/run/secrets/nais.io/vault
-      - kvPath: /oracle/data/dev/config/veilarbaktivitet_{{namespace}}
+      - kvPath: /oracle/data/dev/config/veilarbaktivitet_q1
         mountPath: /var/run/secrets/nais.io/oracle_config
   webproxy: true
   leaderElection: true
@@ -57,10 +57,10 @@ spec:
     enabled: true
   env:
     - name: APP_ENVIRONMENT_NAME
-      value: {{namespace}}
+      value: q1
     - name: ENDRING_PA_AKTIVITET_TOPIC
-      value: aapen-fo-endringPaaAktivitet-v4-{{namespace}}
+      value: aapen-fo-endringPaaAktivitet-v4-q1
     - name: OPPFOLGING_AVSLUTTET_TOPIC
-      value: aapen-arbeidsrettetOppfolging-oppfolgingAvsluttet-v1-{{namespace}}
+      value: aapen-arbeidsrettetOppfolging-oppfolgingAvsluttet-v1-q1
     - name: KVP_AVSLUTTET_TOPIC
-      value: aapen-arbeidsrettetOppfolging-kvpAvsluttet-v1-{{namespace}}
+      value: aapen-arbeidsrettetOppfolging-kvpAvsluttet-v1-q1

--- a/nais.yaml
+++ b/nais.yaml
@@ -2,7 +2,7 @@ kind: Application
 apiVersion: nais.io/v1alpha1
 metadata:
   name: veilarbaktivitet
-  namespace: default
+  namespace: pto
   cluster: prod-fss
   labels:
     team: pto

--- a/src/main/java/no/nav/veilarbaktivitet/config/MessageQueueConfig.java
+++ b/src/main/java/no/nav/veilarbaktivitet/config/MessageQueueConfig.java
@@ -57,7 +57,7 @@ public class MessageQueueConfig {
         JmsFactoryFactory jmsFactoryFactory = JmsFactoryFactory.getInstance(WMQ_PROVIDER);
         JmsConnectionFactory connectionFactory = jmsFactoryFactory.createConnectionFactory();
 
-        String env = requireNamespace().equals("default") ? "p" : requireNamespace();
+        String env = getClusterName().equals("prod-fss") ? "p": "q1";
 
         connectionFactory.setStringProperty(WMQ_HOST_NAME, getRequiredProperty(MQGATEWAY03_HOSTNAME_PROPERTY));
         connectionFactory.setStringProperty(WMQ_PORT, getRequiredProperty(MQGATEWAY03_PORT_PROPERTY));

--- a/src/main/java/no/nav/veilarbaktivitet/config/MessageQueueConfig.java
+++ b/src/main/java/no/nav/veilarbaktivitet/config/MessageQueueConfig.java
@@ -57,7 +57,7 @@ public class MessageQueueConfig {
         JmsFactoryFactory jmsFactoryFactory = JmsFactoryFactory.getInstance(WMQ_PROVIDER);
         JmsConnectionFactory connectionFactory = jmsFactoryFactory.createConnectionFactory();
 
-        String env = getClusterName().equals("prod-fss") ? "p": "q1";
+        String env = getClusterName().orElse("dev-fss").equals("prod-fss") ? "p": "q1";
 
         connectionFactory.setStringProperty(WMQ_HOST_NAME, getRequiredProperty(MQGATEWAY03_HOSTNAME_PROPERTY));
         connectionFactory.setStringProperty(WMQ_PORT, getRequiredProperty(MQGATEWAY03_PORT_PROPERTY));


### PR DESCRIPTION
* Bytter namespace til pto i dev og prod
* Gjør om implementasjon for channel name (brukt av MQ) fordi den så ut til å være laget under antagelsen at man kan endre channel name når man endrer namespace men channel navn må alltid være p eller q1, eller så må det gjøres endringer i tilgangene våre