### PR TITLE
Rydder i datastruktur, separerer CvKanDeles data

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAO.java
@@ -288,13 +288,14 @@ public class AktivitetDAO {
     private void insertStillingFraNav(long aktivitetId, long versjon, StillingFraNavData stillingFraNavData) {
         ofNullable(stillingFraNavData)
                 .ifPresent(stilling -> {
+                    var cvKanDelesData = stilling.getCvKanDelesData();
                             SqlParameterSource parms = new MapSqlParameterSource()
                                     .addValue("aktivitet_id", aktivitetId)
                                     .addValue("versjon", versjon)
-                                    .addValue("cv_kan_deles", stilling.getKanDeles())
-                                    .addValue("cv_kan_deles_tidspunkt", stilling.getCvKanDelesTidspunkt())
-                                    .addValue("cv_kan_deles_av", stilling.getCvKanDelesAv())
-                                    .addValue("cv_kan_deles_av_type", EnumUtils.getName(stilling.getCvKanDelesAvType()))
+                                    .addValue("cv_kan_deles", cvKanDelesData.getKanDeles())
+                                    .addValue("cv_kan_deles_tidspunkt", cvKanDelesData.getEndretTidspunkt())
+                                    .addValue("cv_kan_deles_av", cvKanDelesData.getEndretAv())
+                                    .addValue("cv_kan_deles_av_type", EnumUtils.getName(cvKanDelesData.getEndretAvType()))
                                     .addValue("soknadsfrist", stilling.getSoknadsfrist())
                                     .addValue("svarfrist", stilling.getSvarfrist())
                                     .addValue("arbeidsgiver", stilling.getArbeidsgiver())

--- a/src/main/java/no/nav/veilarbaktivitet/db/rowmappers/AktivitetDataRowMapper.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/rowmappers/AktivitetDataRowMapper.java
@@ -2,6 +2,7 @@ package no.nav.veilarbaktivitet.db.rowmappers;
 
 import lombok.val;
 import no.nav.veilarbaktivitet.db.Database;
+import no.nav.veilarbaktivitet.stilling_fra_nav.CvKanDelesData;
 import no.nav.veilarbaktivitet.stilling_fra_nav.StillingFraNavData;
 import no.nav.veilarbaktivitet.domain.*;
 import no.nav.veilarbaktivitet.util.EnumUtils;
@@ -130,11 +131,15 @@ public class AktivitetDataRowMapper {
     private static StillingFraNavData mapStillingFraNav(ResultSet rs) throws SQLException {
         //TODO fiks
         // soknadsfrist, svarFrist, arbeidsgiver, bestillingsId‚ stillingsId, arbeidsSted, varselid
-        return StillingFraNavData.builder()
+        var cvKanDelesData = CvKanDelesData.builder()
                 .kanDeles(rs.getBoolean("cv_kan_deles"))
-                .cvKanDelesAv(rs.getString("cv_kan_deles_av"))
-                .cvKanDelesTidspunkt(Database.hentDato(rs, "cv_kan_deles_tidspunkt"))
-                .cvKanDelesAvType(EnumUtils.valueOf(InnsenderData.class, rs.getString("cv_kan_deles_av_type")))
+                .endretAv(rs.getString("cv_kan_deles_av"))
+                .endretTidspunkt(Database.hentDato(rs, "cv_kan_deles_tidspunkt"))
+                .endretAvType(EnumUtils.valueOf(InnsenderData.class, rs.getString("cv_kan_deles_av_type")))
+                .build();
+
+        return StillingFraNavData.builder()
+                .cvKanDelesData(cvKanDelesData)
                 .soknadsfrist(rs.getString("soknadsfrist"))
                 .svarfrist(rs.getDate("svarFrist"))
                 .arbeidsgiver(rs.getString("arbeidsgiver"))

--- a/src/main/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapper.java
+++ b/src/main/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapper.java
@@ -45,7 +45,8 @@ public class AktivitetDTOMapper {
     }
 
     private static void mapStillingFraNavData(AktivitetDTO aktivitetDTO, StillingFraNavData stillingFraNavData, boolean erEkstern) {
-        aktivitetDTO.setStillingFraNavData(stillingFraNavData.withCvKanDelesAv(erEkstern ? null : stillingFraNavData.getCvKanDelesAv()));
+        var cvKanDelesData = stillingFraNavData.getCvKanDelesData().withEndretAv(erEkstern ? null : stillingFraNavData.getCvKanDelesData().getEndretAv());
+        aktivitetDTO.setStillingFraNavData(stillingFraNavData.withCvKanDelesData(cvKanDelesData));
     }
 
     private static void mapMoteData(AktivitetDTO aktivitetDTO, MoteData moteData) {

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
@@ -197,12 +197,16 @@ public class AktivitetService {
         metricService.oppdaterAktivitetMetrikk(aktivitet, blittAvtalt, originalAktivitet.isAutomatiskOpprettet());
     }
 
+    //TODO: Det er riktig at man kun kan endre cv data??
     private StillingFraNavData mergeDelingAvCvData(StillingFraNavData orginal, StillingFraNavData aktivitet) {
-        return orginal
-                .withKanDeles(aktivitet.getKanDeles())
-                .withCvKanDelesTidspunkt(aktivitet.getCvKanDelesTidspunkt())
-                .withCvKanDelesAv(aktivitet.getCvKanDelesAv())
-                .withCvKanDelesAvType(aktivitet.getCvKanDelesAvType());
+        var nyeCvData = aktivitet.getCvKanDelesData();
+        var cvKanDelesData =  orginal.getCvKanDelesData()
+                .withKanDeles(nyeCvData.getKanDeles())
+                .withEndretTidspunkt(nyeCvData.getEndretTidspunkt())
+                .withEndretAv(nyeCvData.getEndretAv())
+                .withEndretAvType(nyeCvData.getEndretAvType());
+
+        return orginal.withCvKanDelesData(cvKanDelesData);
     }
 
 

--- a/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/CvKanDelesData.java
+++ b/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/CvKanDelesData.java
@@ -1,0 +1,19 @@
+package no.nav.veilarbaktivitet.stilling_fra_nav;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.With;
+import no.nav.veilarbaktivitet.domain.InnsenderData;
+
+import java.util.Date;
+
+@Builder
+@With
+@Getter
+public class CvKanDelesData {
+    Boolean kanDeles;
+    Date endretTidspunkt;
+    String endretAv;
+    InnsenderData endretAvType;
+
+}

--- a/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/DelingAvCvService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/DelingAvCvService.java
@@ -29,14 +29,16 @@ public class DelingAvCvService {
     public AktivitetData oppdaterSvarPaaOmCvSkalDeles(AktivitetData aktivitetData, boolean kanDeles, boolean erEksternBruker) {
         Person innloggetBruker = authService.getLoggedInnUser().orElseThrow(RuntimeException::new);
 
-        var deleCvDetaljer = aktivitetData
-                .getStillingFraNavData()
-                .withKanDeles(kanDeles)
-                .withCvKanDelesTidspunkt(new Date())
-                .withCvKanDelesAvType(erEksternBruker? InnsenderData.BRUKER : InnsenderData.NAV)
-                .withCvKanDelesAv(innloggetBruker.get());
+        var deleCvDetaljer = CvKanDelesData.builder()
+                .kanDeles(kanDeles)
+                .endretTidspunkt(new Date())
+                .endretAvType(erEksternBruker? InnsenderData.BRUKER : InnsenderData.NAV)
+                .endretAv(innloggetBruker.get())
+                .build();
 
-        aktivitetService.oppdaterAktivitet(aktivitetData, aktivitetData.withStillingFraNavData(deleCvDetaljer), innloggetBruker);
+        var stillingFraNavData = aktivitetData.getStillingFraNavData().withCvKanDelesData(deleCvDetaljer);
+
+        aktivitetService.oppdaterAktivitet(aktivitetData, aktivitetData.withStillingFraNavData(stillingFraNavData), innloggetBruker);
         var aktivitetMedCvSvar = aktivitetService.hentAktivitetMedForhaandsorientering(aktivitetData.getId());
 
         if (kanDeles) {

--- a/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavData.java
+++ b/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavData.java
@@ -3,18 +3,13 @@ package no.nav.veilarbaktivitet.stilling_fra_nav;
 import lombok.Builder;
 import lombok.Data;
 import lombok.With;
-import no.nav.veilarbaktivitet.domain.InnsenderData;
-
 import java.util.Date;
 
 @Data
 @Builder
 @With
 public class StillingFraNavData {
-    Boolean kanDeles;
-    Date cvKanDelesTidspunkt;
-    String cvKanDelesAv;
-    InnsenderData cvKanDelesAvType;
+    CvKanDelesData cvKanDelesData;
     String soknadsfrist;
     Date svarfrist;
     String arbeidsgiver;

--- a/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDTOControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/avtaltMedNav/ForhaandsorienteringDTOControllerTest.java
@@ -238,11 +238,13 @@ public class ForhaandsorienteringDTOControllerTest {
                     .id(resultatDTO.getForhaandsorientering().getId())
                     .build();
 
+            resultatDTO.setStillingFraNavData(null);
             AktivitetData forventet = orginal
                     .toBuilder()
                     .avtalt(true)
                     .forhaandsorientering(forventetFHO)
                     .transaksjonsType(AktivitetTransaksjonsType.AVTALT)
+                    .stillingFraNavData(null)
                     //endres altid ved oppdatering
                     .versjon(Long.parseLong(resultatDTO.getVersjon()))
                     .lagtInnAv(InnsenderData.NAV)

--- a/src/test/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapperTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapperTest.java
@@ -161,12 +161,13 @@ public class AktivitetDTOMapperTest {
     public void skalMappeStillingFraNavData() {
         AktivitetData nyStillingFraNav = AktivitetDataTestBuilder.nyStillingFraNav();
         AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyStillingFraNav, false);
+
         SoftAssertions.assertSoftly( s -> {
             s.assertThat(aktivitetDTO.getType()).isEqualTo(AktivitetTypeDTO.STILLING_FRA_NAV);
-            s.assertThat(aktivitetDTO.getStillingFraNavData().getKanDeles()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getKanDeles());
-            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesAv()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesAv());
-            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesAvType()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesAvType());
-            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesTidspunkt()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesTidspunkt());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesData().getKanDeles()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesData().getKanDeles());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesData().getEndretAv()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesData().getEndretAv());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesData().getEndretAvType()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesData().getEndretAvType());
+            s.assertThat(aktivitetDTO.getStillingFraNavData().getCvKanDelesData().getEndretTidspunkt()).isEqualTo(nyStillingFraNav.getStillingFraNavData().getCvKanDelesData().getEndretTidspunkt());
 
             s.assertAll();
         });

--- a/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavControllerTest.java
@@ -87,10 +87,10 @@ public class StillingFraNavControllerTest {
 
         var resultat = stillingFraNavController.oppdaterKanCvDeles(aktivitetData.getId(), delingAvCvDTO);
         var resultatJobbannonse = resultat.getStillingFraNavData();
-        Assert.assertTrue(resultatJobbannonse.getKanDeles());
-        Assert.assertNotNull(resultatJobbannonse.getCvKanDelesTidspunkt());
-        Assert.assertEquals(InnsenderData.NAV, resultatJobbannonse.getCvKanDelesAvType());
-        Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatJobbannonse.getCvKanDelesAv());
+        Assert.assertTrue(resultatJobbannonse.getCvKanDelesData().getKanDeles());
+        Assert.assertNotNull(resultatJobbannonse.getCvKanDelesData().getEndretTidspunkt());
+        Assert.assertEquals(InnsenderData.NAV, resultatJobbannonse.getCvKanDelesData().getEndretAvType());
+        Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatJobbannonse.getCvKanDelesData().getEndretAv());
         Assert.assertEquals(AktivitetStatus.GJENNOMFORES, resultat.getStatus());
 
     }
@@ -105,10 +105,10 @@ public class StillingFraNavControllerTest {
         var resultatJobbannonse = resultat.getStillingFraNavData();
         Assert.assertEquals(AktivitetStatus.AVBRUTT, resultat.getStatus());
 
-        Assert.assertFalse(resultatJobbannonse.getKanDeles());
-        Assert.assertNotNull(resultatJobbannonse.getCvKanDelesTidspunkt());
-        Assert.assertEquals(InnsenderData.NAV, resultatJobbannonse.getCvKanDelesAvType());
-        Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatJobbannonse.getCvKanDelesAv());
+        Assert.assertFalse(resultatJobbannonse.getCvKanDelesData().getKanDeles());
+        Assert.assertNotNull(resultatJobbannonse.getCvKanDelesData().getEndretTidspunkt());
+        Assert.assertEquals(InnsenderData.NAV, resultatJobbannonse.getCvKanDelesData().getEndretAvType());
+        Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatJobbannonse.getCvKanDelesData().getEndretAv());
 
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
+++ b/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
@@ -1,5 +1,6 @@
 package no.nav.veilarbaktivitet.testutils;
 
+import no.nav.veilarbaktivitet.stilling_fra_nav.CvKanDelesData;
 import no.nav.veilarbaktivitet.stilling_fra_nav.StillingFraNavData;
 import no.nav.veilarbaktivitet.domain.*;
 
@@ -68,13 +69,17 @@ public class AktivitetTypeDataTesBuilder {
     }
 
     public static StillingFraNavData nyStillingFraNav() {
+        var cvKanDelesData = CvKanDelesData.builder()
+                .endretAvType(InnsenderData.NAV)
+                .endretAv("Z999999")
+                .endretTidspunkt(AktivitetDataTestBuilder.nyDato())
+                .kanDeles(Boolean.TRUE)
+                .build();
+
         return StillingFraNavData.builder()
                 .bestillingsId("123")
                 .stillingsId("1234")
-                .cvKanDelesAvType(InnsenderData.NAV)
-                .cvKanDelesAv("Z999999")
-                .cvKanDelesTidspunkt(AktivitetDataTestBuilder.nyDato())
-                .kanDeles(Boolean.TRUE)
+                .cvKanDelesData(cvKanDelesData)
                 .build();
     }
 }


### PR DESCRIPTION
Rydder i datastrukturen for å gjøre det lettere for frontend å sjekke om svar er angitt