### PR TITLE
Fikser diverse feil med dele cv

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAO.java
@@ -23,15 +23,16 @@ import static java.util.Optional.ofNullable;
 @Slf4j
 public class AktivitetDAO {
 
+    // TODO: Refaktorer spørring. Her joines mange tabeller som kan ha kolonner med samme navn. Hva som hentes ut av ResultSet kommer an på rekkefølgen det joines.
     // language=sql
-    private static final String SELECT_AKTIVITET = "SELECT * FROM AKTIVITET A " +
+    private static final String SELECT_AKTIVITET = "SELECT SFN.ARBEIDSGIVER as \"STILLING_FRA_NAV.ARBEIDSGIVER\", SFN.ARBEIDSSTED as \"STILLING_FRA_NAV.ARBEIDSSTED\", A.*, S.*, E.*, SA.*, IJ.*, M.*, B.*, SFN.* FROM AKTIVITET A " +
             "LEFT JOIN STILLINGSSOK S ON A.aktivitet_id = S.aktivitet_id AND A.versjon = S.versjon " +
             "LEFT JOIN EGENAKTIVITET E ON A.aktivitet_id = E.aktivitet_id AND A.versjon = E.versjon " +
             "LEFT JOIN SOKEAVTALE SA ON A.aktivitet_id = SA.aktivitet_id AND A.versjon = SA.versjon " +
             "LEFT JOIN IJOBB IJ ON A.aktivitet_id = IJ.aktivitet_id AND A.versjon = IJ.versjon " +
             "LEFT JOIN MOTE M ON A.aktivitet_id = M.aktivitet_id AND A.versjon = M.versjon " +
             "LEFT JOIN BEHANDLING B ON A.aktivitet_id = B.aktivitet_id AND A.versjon = B.versjon " +
-            "LEFT JOIN STILLING_FRA_NAV sn on A.AKTIVITET_ID = sn.AKTIVITET_ID and A.VERSJON = sn.VERSJON ";
+            "LEFT JOIN STILLING_FRA_NAV SFN on A.aktivitet_id = SFN.aktivitet_id and A.versjon = SFN.versjon ";
 
     private final Database database;
 
@@ -52,7 +53,7 @@ public class AktivitetDAO {
     public AktivitetData hentAktivitet(long aktivitetId) {
         // language=sql
         return database.queryForObject(SELECT_AKTIVITET +
-                        "WHERE A.aktivitet_id = ? and gjeldende = 1",
+                        " WHERE A.aktivitet_id = ? and gjeldende = 1",
                 AktivitetDataRowMapper::mapAktivitet,
                 aktivitetId
         );
@@ -264,7 +265,6 @@ public class AktivitetDAO {
                     );
                 });
     }
-
 
     private void insertBehandling(long aktivitetId, long versjon, BehandlingAktivitetData behandlingAktivitet) {
         ofNullable(behandlingAktivitet)

--- a/src/main/java/no/nav/veilarbaktivitet/db/rowmappers/AktivitetDataRowMapper.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/rowmappers/AktivitetDataRowMapper.java
@@ -130,16 +130,16 @@ public class AktivitetDataRowMapper {
 
     private static StillingFraNavData mapStillingFraNav(ResultSet rs) throws SQLException {
         //TODO fiks
-        // soknadsfrist, svarFrist, arbeidsgiver, bestillingsId‚ stillingsId, arbeidsSted, varselid
+        // soknadsfrist, svarFrist, arbeidsgiver, bestillingsId‚ stillingsId, arbeidsSted, varsel
         var cvKanDelesData = CvKanDelesData.builder()
-                .kanDeles(rs.getBoolean("cv_kan_deles"))
+                .kanDeles(rs.getObject("cv_kan_deles", Boolean.class))
                 .endretAv(rs.getString("cv_kan_deles_av"))
                 .endretTidspunkt(Database.hentDato(rs, "cv_kan_deles_tidspunkt"))
                 .endretAvType(EnumUtils.valueOf(InnsenderData.class, rs.getString("cv_kan_deles_av_type")))
                 .build();
 
         return StillingFraNavData.builder()
-                .cvKanDelesData(cvKanDelesData)
+                .cvKanDelesData(cvKanDelesData.getKanDeles() == null ? null: cvKanDelesData)
                 .soknadsfrist(rs.getString("soknadsfrist"))
                 .svarfrist(rs.getDate("svarFrist"))
                 .arbeidsgiver(rs.getString("arbeidsgiver"))

--- a/src/main/java/no/nav/veilarbaktivitet/db/rowmappers/AktivitetDataRowMapper.java
+++ b/src/main/java/no/nav/veilarbaktivitet/db/rowmappers/AktivitetDataRowMapper.java
@@ -142,10 +142,10 @@ public class AktivitetDataRowMapper {
                 .cvKanDelesData(cvKanDelesData.getKanDeles() == null ? null: cvKanDelesData)
                 .soknadsfrist(rs.getString("soknadsfrist"))
                 .svarfrist(rs.getDate("svarFrist"))
-                .arbeidsgiver(rs.getString("arbeidsgiver"))
+                .arbeidsgiver(rs.getString("STILLING_FRA_NAV.ARBEIDSGIVER"))
                 .bestillingsId(rs.getString("bestillingsId"))
                 .stillingsId(rs.getString("stillingsId"))
-                .arbeidssted(rs.getString("arbeidsSted"))
+                .arbeidssted(rs.getString("STILLING_FRA_NAV.ARBEIDSSTED"))
                 .varselId(rs.getString("varselid"))
                 .build();
     }

--- a/src/main/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapper.java
+++ b/src/main/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapper.java
@@ -2,6 +2,7 @@ package no.nav.veilarbaktivitet.mappers;
 
 import no.nav.veilarbaktivitet.avtaltMedNav.Forhaandsorientering;
 import no.nav.veilarbaktivitet.avtaltMedNav.ForhaandsorienteringDTO;
+import no.nav.veilarbaktivitet.stilling_fra_nav.CvKanDelesData;
 import no.nav.veilarbaktivitet.stilling_fra_nav.StillingFraNavData;
 import no.nav.veilarbaktivitet.domain.*;
 import no.nav.veilarbaktivitet.util.FunctionUtils;
@@ -45,7 +46,11 @@ public class AktivitetDTOMapper {
     }
 
     private static void mapStillingFraNavData(AktivitetDTO aktivitetDTO, StillingFraNavData stillingFraNavData, boolean erEkstern) {
-        var cvKanDelesData = stillingFraNavData.getCvKanDelesData().withEndretAv(erEkstern ? null : stillingFraNavData.getCvKanDelesData().getEndretAv());
+        CvKanDelesData cvKanDelesData = null;
+
+        if(stillingFraNavData.getCvKanDelesData() != null) {
+            cvKanDelesData = stillingFraNavData.getCvKanDelesData().withEndretAv(erEkstern ? null : stillingFraNavData.getCvKanDelesData().getEndretAv());
+        }
         aktivitetDTO.setStillingFraNavData(stillingFraNavData.withCvKanDelesData(cvKanDelesData));
     }
 

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
@@ -200,19 +200,11 @@ public class AktivitetService {
 
     //TODO: Det er riktig at man kun kan endre cv data??
     private StillingFraNavData mergeStillingFraNavData(StillingFraNavData orginal, StillingFraNavData aktivitet) {
-        val merger = MappingUtils.merge(orginal, aktivitet);
+        var nyCvKanDeles = aktivitet.getCvKanDelesData();
+
         return orginal
-                .withCvKanDelesData(merger.map(StillingFraNavData::getCvKanDelesData).merge(this::mergeCvKanDelesData));
+                .withCvKanDelesData(nyCvKanDeles);
     }
-
-    private CvKanDelesData mergeCvKanDelesData(CvKanDelesData original, CvKanDelesData cvKanDelesData) {
-        return original
-                .withKanDeles(cvKanDelesData.getKanDeles())
-                .withEndretAv(cvKanDelesData.getEndretAv())
-                .withEndretAvType(cvKanDelesData.getEndretAvType())
-                .withEndretTidspunkt(cvKanDelesData.getEndretTidspunkt());
-    }
-
 
     private BehandlingAktivitetData mergeBehandlingAktivitetData(BehandlingAktivitetData originalBehandlingAktivitetData, BehandlingAktivitetData behandlingAktivitetData) {
         return originalBehandlingAktivitetData

--- a/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/CvKanDelesData.java
+++ b/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/CvKanDelesData.java
@@ -1,8 +1,6 @@
 package no.nav.veilarbaktivitet.stilling_fra_nav;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.With;
+import lombok.*;
 import no.nav.veilarbaktivitet.domain.InnsenderData;
 
 import java.util.Date;
@@ -10,6 +8,7 @@ import java.util.Date;
 @Builder
 @With
 @Getter
+@Data
 public class CvKanDelesData {
     Boolean kanDeles;
     Date endretTidspunkt;

--- a/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavController.java
+++ b/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavController.java
@@ -22,7 +22,7 @@ public class StillingFraNavController {
     private final DelingAvCvService service;
 
     @PutMapping("/kanDeleCV")
-    public AktivitetDTO oppdaterKanCvDeles(@PathVariable(value="aktivitetId") long aktivitetId, @RequestBody DelingAvCvDTO delingAvCvDTO) {
+    public AktivitetDTO oppdaterKanCvDeles(@RequestParam long aktivitetId, @RequestBody DelingAvCvDTO delingAvCvDTO) {
         boolean erEksternBruker = authService.erEksternBruker();
         var aktivitet = aktivitetAppService
                 .hentAktivitet(aktivitetId);

--- a/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
@@ -30,7 +30,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static no.nav.veilarbaktivitet.mock.TestData.*;
-import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.nyttStillingssøk;
+import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -121,6 +121,19 @@ public class AktivitetsplanRSTest {
         Assert.assertNull(resultat.getAktiviteter().get(0).getForhaandsorientering());
         Assert.assertNotNull(resultat.getAktiviteter().get(1).getForhaandsorientering());
 
+
+    }
+
+    @Test
+    public void hentAktivitetsplan_henterStillingFraNavData() {
+        var aktivitet = nyStillingFraNav().withAktorId(KJENT_AKTOR_ID.get());
+        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(aktivitet);
+
+        var resultat = aktivitetController.hentAktivitetsplan();
+        var resultatAktivitet = resultat.getAktiviteter().get(0);
+        Assert.assertEquals(1, resultat.getAktiviteter().size());
+        Assert.assertEquals(String.valueOf(aktivitetData.getId()), resultatAktivitet.getId());
+        Assert.assertNull(resultatAktivitet.getStillingFraNavData().getCvKanDelesData());
 
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
@@ -125,7 +125,7 @@ public class AktivitetsplanRSTest {
     }
 
     @Test
-    public void hentAktivitetsplan_henterStillingFraNavData() {
+    public void hentAktivitetsplan_henterStillingFraNavDataUtenCVData() {
         var aktivitet = nyStillingFraNav().withAktorId(KJENT_AKTOR_ID.get());
         AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(aktivitet);
 
@@ -134,6 +134,32 @@ public class AktivitetsplanRSTest {
         Assert.assertEquals(1, resultat.getAktiviteter().size());
         Assert.assertEquals(String.valueOf(aktivitetData.getId()), resultatAktivitet.getId());
         Assert.assertNull(resultatAktivitet.getStillingFraNavData().getCvKanDelesData());
+
+    }
+
+    @Test
+    public void hentAktivitetsplan_henterStillingFraNavDataMedCVData() {
+        var aktivitet = nyStillingFraNavMedCVKanDeles().withAktorId(KJENT_AKTOR_ID.get());
+        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(aktivitet);
+
+        var resultat = aktivitetController.hentAktivitetsplan();
+        var resultatAktivitet = resultat.getAktiviteter().get(0);
+        Assert.assertEquals(1, resultat.getAktiviteter().size());
+        Assert.assertEquals(String.valueOf(aktivitetData.getId()), resultatAktivitet.getId());
+        Assert.assertNotNull(resultatAktivitet.getStillingFraNavData().getCvKanDelesData());
+        Assert.assertTrue(resultatAktivitet.getStillingFraNavData().getCvKanDelesData().getKanDeles());
+    }
+
+    @Test
+    public void hentAktivitetsplan_henterStillingFraNavDataMedCvSvar() {
+        var aktivitet = nyStillingFraNavMedCVKanDeles().withAktorId(KJENT_AKTOR_ID.get());
+        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(aktivitet);
+
+        var resultat = aktivitetController.hentAktivitetsplan();
+        var resultatAktivitet = resultat.getAktiviteter().get(0);
+        Assert.assertEquals(1, resultat.getAktiviteter().size());
+        Assert.assertEquals(String.valueOf(aktivitetData.getId()), resultatAktivitet.getId());
+        Assert.assertTrue(resultatAktivitet.getStillingFraNavData().getCvKanDelesData().getKanDeles());
 
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAOTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/db/dao/AktivitetDAOTest.java
@@ -2,36 +2,23 @@ package no.nav.veilarbaktivitet.db.dao;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import no.nav.veilarbaktivitet.db.Database;
 import no.nav.veilarbaktivitet.db.DbTestUtils;
 import no.nav.veilarbaktivitet.domain.AktivitetData;
 import no.nav.veilarbaktivitet.domain.AktivitetTransaksjonsType;
 import no.nav.veilarbaktivitet.domain.Person;
-import no.nav.veilarbaktivitet.mock.LocalH2Database;
 import no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import javax.sql.DataSource;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -43,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @Slf4j
@@ -128,6 +116,15 @@ public class AktivitetDAOTest {
 
         assertThat(aktiviteter, hasSize(1));
         assertThat(aktivitet, equalTo(aktiviteter.get(0)));
+    }
+
+    @Test
+    public void opprette_og_hente_stillingFraNAV() {
+        var aktivitet = gitt_at_det_finnes_en_stillingFraNav();
+        var aktiviteter = aktivitetDAO.hentAktiviteterForAktorId(AKTOR_ID);
+
+        assertEquals(1, aktiviteter.size());
+        assertEquals(aktivitet, aktiviteter.get(0));
     }
 
     @Test
@@ -242,6 +239,10 @@ public class AktivitetDAOTest {
 
     private AktivitetData gitt_at_det_finnes_et_samtalereferat() {
         return addAktivitet(AktivitetDataTestBuilder.nytSamtaleReferat());
+    }
+
+    private AktivitetData gitt_at_det_finnes_en_stillingFraNav() {
+        return addAktivitet(AktivitetDataTestBuilder.nyStillingFraNavMedCVKanDeles());
     }
 
     private AktivitetData naar_jeg_oppdaterer_en_aktivitet(AktivitetData aktivitetData) {

--- a/src/test/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapperTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/mappers/AktivitetDTOMapperTest.java
@@ -208,7 +208,7 @@ public class AktivitetDTOMapperTest {
 
     @Test
     public void skalMappeStillingFraNavData() {
-        AktivitetData nyStillingFraNav = AktivitetDataTestBuilder.nyStillingFraNav();
+        AktivitetData nyStillingFraNav = AktivitetDataTestBuilder.nyStillingFraNavMedCVKanDeles();
         AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(nyStillingFraNav, false);
 
         SoftAssertions.assertSoftly( s -> {

--- a/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavControllerTest.java
@@ -31,7 +31,7 @@ import java.util.Random;
 
 import static no.nav.veilarbaktivitet.mock.TestData.*;
 import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.nyMoteAktivitet;
-import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.nyStillingFraNav;
+import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.nyStillingFraNavMedCVKanDeles;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -81,7 +81,7 @@ public class StillingFraNavControllerTest {
 
     @Test
     public void oppdaterKanCvDeles_NavSvarerJA_setterAlleVerdier() {
-        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(nyStillingFraNav());
+        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(nyStillingFraNavMedCVKanDeles());
         AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetData,false);
         DelingAvCvDTO delingAvCvDTO = new DelingAvCvDTO(Long.parseLong(aktivitetDTO.getVersjon()), true);
 
@@ -97,7 +97,7 @@ public class StillingFraNavControllerTest {
 
     @Test
     public void oppdaterKanCvDeles_NavSvarerNEI_setterAlleVerdier() {
-        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(nyStillingFraNav().withAktorId(KJENT_AKTOR_ID.get()));
+        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(nyStillingFraNavMedCVKanDeles().withAktorId(KJENT_AKTOR_ID.get()));
         AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetData,false);
         DelingAvCvDTO delingAvCvDTO = new DelingAvCvDTO(Long.parseLong(aktivitetDTO.getVersjon()), false);
 

--- a/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/StillingFraNavControllerTest.java
@@ -30,8 +30,7 @@ import java.util.Optional;
 import java.util.Random;
 
 import static no.nav.veilarbaktivitet.mock.TestData.*;
-import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.nyMoteAktivitet;
-import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.nyStillingFraNavMedCVKanDeles;
+import static no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -81,16 +80,17 @@ public class StillingFraNavControllerTest {
 
     @Test
     public void oppdaterKanCvDeles_NavSvarerJA_setterAlleVerdier() {
-        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(nyStillingFraNavMedCVKanDeles());
+        AktivitetData aktivitetData = aktivitetDAO.opprettNyAktivitet(nyStillingFraNav());
         AktivitetDTO aktivitetDTO = AktivitetDTOMapper.mapTilAktivitetDTO(aktivitetData,false);
         DelingAvCvDTO delingAvCvDTO = new DelingAvCvDTO(Long.parseLong(aktivitetDTO.getVersjon()), true);
 
         var resultat = stillingFraNavController.oppdaterKanCvDeles(aktivitetData.getId(), delingAvCvDTO);
-        var resultatJobbannonse = resultat.getStillingFraNavData();
-        Assert.assertTrue(resultatJobbannonse.getCvKanDelesData().getKanDeles());
-        Assert.assertNotNull(resultatJobbannonse.getCvKanDelesData().getEndretTidspunkt());
-        Assert.assertEquals(InnsenderData.NAV, resultatJobbannonse.getCvKanDelesData().getEndretAvType());
-        Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatJobbannonse.getCvKanDelesData().getEndretAv());
+        var resultatStilling = resultat.getStillingFraNavData();
+
+        Assert.assertTrue(resultatStilling.getCvKanDelesData().getKanDeles());
+        Assert.assertNotNull(resultatStilling.getCvKanDelesData().getEndretTidspunkt());
+        Assert.assertEquals(InnsenderData.NAV, resultatStilling.getCvKanDelesData().getEndretAvType());
+        Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatStilling.getCvKanDelesData().getEndretAv());
         Assert.assertEquals(AktivitetStatus.GJENNOMFORES, resultat.getStatus());
 
     }
@@ -103,12 +103,13 @@ public class StillingFraNavControllerTest {
 
         var resultat = stillingFraNavController.oppdaterKanCvDeles(aktivitetData.getId(), delingAvCvDTO);
         var resultatJobbannonse = resultat.getStillingFraNavData();
-        Assert.assertEquals(AktivitetStatus.AVBRUTT, resultat.getStatus());
 
         Assert.assertFalse(resultatJobbannonse.getCvKanDelesData().getKanDeles());
         Assert.assertNotNull(resultatJobbannonse.getCvKanDelesData().getEndretTidspunkt());
         Assert.assertEquals(InnsenderData.NAV, resultatJobbannonse.getCvKanDelesData().getEndretAvType());
         Assert.assertEquals(KJENT_SAKSBEHANDLER.get(), resultatJobbannonse.getCvKanDelesData().getEndretAv());
+        Assert.assertEquals(AktivitetStatus.AVBRUTT, resultat.getStatus());
+
 
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetDataTestBuilder.java
+++ b/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetDataTestBuilder.java
@@ -51,16 +51,23 @@ public class AktivitetDataTestBuilder {
             case SAMTALEREFERAT:
                 return nytSamtaleReferat();
             case STILLING_FRA_NAV:
-                return nyStillingFraNav();
+                return nyStillingFraNavMedCVKanDeles();
             default: throw new IllegalArgumentException("ukjent type");
         }
 
     }
 
+    public static AktivitetData nyStillingFraNavMedCVKanDeles() {
+        return AktivitetDataTestBuilder.nyAktivitet()
+                .aktivitetType(AktivitetTypeData.STILLING_FRA_NAV)
+                .stillingFraNavData(AktivitetTypeDataTesBuilder.nyStillingFraNav(true))
+                .build();
+    }
+
     public static AktivitetData nyStillingFraNav() {
         return AktivitetDataTestBuilder.nyAktivitet()
                 .aktivitetType(AktivitetTypeData.STILLING_FRA_NAV)
-                .stillingFraNavData(AktivitetTypeDataTesBuilder.nyStillingFraNav())
+                .stillingFraNavData(AktivitetTypeDataTesBuilder.nyStillingFraNav(false))
                 .build();
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
+++ b/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
@@ -4,6 +4,8 @@ import no.nav.veilarbaktivitet.stilling_fra_nav.CvKanDelesData;
 import no.nav.veilarbaktivitet.stilling_fra_nav.StillingFraNavData;
 import no.nav.veilarbaktivitet.domain.*;
 
+import java.util.Date;
+
 public class AktivitetTypeDataTesBuilder {
 
     public static StillingsoekAktivitetData nyttStillingssøk() {
@@ -69,7 +71,7 @@ public class AktivitetTypeDataTesBuilder {
     }
 
     public static StillingFraNavData nyStillingFraNav(boolean setCVKanDelesData) {
-        CvKanDelesData cvKanDelesData;
+        CvKanDelesData cvKanDelesData = null;
 
         if(setCVKanDelesData){
             cvKanDelesData = CvKanDelesData.builder()
@@ -80,12 +82,13 @@ public class AktivitetTypeDataTesBuilder {
                     .build();
         }
 
-        else cvKanDelesData = CvKanDelesData.builder().build();
-
         return StillingFraNavData.builder()
                 .bestillingsId("123")
                 .stillingsId("1234")
                 .cvKanDelesData(cvKanDelesData)
+                .arbeidsgiver("NAV IT")
+                .arbeidssted("Oslo")
+                .soknadsfrist(new Date().toString())
                 .build();
     }
 }

--- a/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
+++ b/src/test/java/no/nav/veilarbaktivitet/testutils/AktivitetTypeDataTesBuilder.java
@@ -68,13 +68,19 @@ public class AktivitetTypeDataTesBuilder {
                 .build();
     }
 
-    public static StillingFraNavData nyStillingFraNav() {
-        var cvKanDelesData = CvKanDelesData.builder()
-                .endretAvType(InnsenderData.NAV)
-                .endretAv("Z999999")
-                .endretTidspunkt(AktivitetDataTestBuilder.nyDato())
-                .kanDeles(Boolean.TRUE)
-                .build();
+    public static StillingFraNavData nyStillingFraNav(boolean setCVKanDelesData) {
+        CvKanDelesData cvKanDelesData;
+
+        if(setCVKanDelesData){
+            cvKanDelesData = CvKanDelesData.builder()
+                    .endretAvType(InnsenderData.NAV)
+                    .endretAv("Z999999")
+                    .endretTidspunkt(AktivitetDataTestBuilder.nyDato())
+                    .kanDeles(Boolean.TRUE)
+                    .build();
+        }
+
+        else cvKanDelesData = CvKanDelesData.builder().build();
 
         return StillingFraNavData.builder()
                 .bestillingsId("123")


### PR DESCRIPTION
https://trello.com/c/NcruKqJc/281-gj%C3%B8re-det-mulig-for-bruker-%C3%A5-svare-p%C3%A5-om-cv-skal-deles

Fikser flere feil som dukket opp når jeg tester i miljø
* Uthenting av aktivitetId skal være @RequestParam
* Uthenting av nullable Boolean må bruke Resultset getObject og ikke getBoolean eller så blir den satt til false når den er null
* Hele CVKanDelesData skal være null når svar ikke er angitt
* arbeidsgiver og arbeidssted kunne ikke hentes ut fordi alle tabellene joines og JOBBSOEKING og STILLING_FRA_NAV hadde  begge kolonner med samme navn. Burde fikses mer generelt for å unngå samme problem igjen med andre kolonner men det var ikke lett å finne en løsning. Kan ikke hente ut kolonne fra spesifikk tabell med ResultSet og conditional joining/union basert på aktivitetstype blir vanskelig fordi resultatet ville hatt forskjellig antall kolonner som ikke er gyldig syntaks.
