### PR TITLE
Fix for automatiske aktiviteter med kvp

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/domain/AktivitetData.java
+++ b/src/main/java/no/nav/veilarbaktivitet/domain/AktivitetData.java
@@ -1,9 +1,6 @@
 package no.nav.veilarbaktivitet.domain;
 
-import lombok.Builder;
-import lombok.ToString;
-import lombok.Value;
-import lombok.With;
+import lombok.*;
 import no.nav.veilarbaktivitet.avtaltMedNav.Forhaandsorientering;
 import no.nav.veilarbaktivitet.stilling_fra_nav.StillingFraNavData;
 

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetAppService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetAppService.java
@@ -98,8 +98,10 @@ public class AktivitetAppService {
                 aktorId :
                 authService.getLoggedInnUser().orElseThrow(RuntimeException::new);
 
-        long id = aktivitetService.opprettAktivitet(aktorId, aktivitetData, loggedInUser);
-        return this.hentAktivitet(id); // this is done because of KVP
+        AktivitetData nyAktivitet = aktivitetService.opprettAktivitet(aktorId, aktivitetData, loggedInUser);
+
+        // dette er gjort på grunn av KVP
+        return authService.erSystemBruker() ? nyAktivitet.withKontorsperreEnhetId(null) : nyAktivitet;
     }
 
     @Transactional

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetAppService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetAppService.java
@@ -85,6 +85,7 @@ public class AktivitetAppService {
         return !aktivitetData.getMoteData().isReferatPublisert() && referatEndret;
     }
 
+    @Transactional
     public AktivitetData opprettNyAktivitet(Person ident, AktivitetData aktivitetData) {
         authService.sjekkTilgangTilPerson(ident);
 

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetAppService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetAppService.java
@@ -148,27 +148,12 @@ public class AktivitetAppService {
         }
     }
 
-    private void kanEndreAktivitetEtikettGuard(AktivitetData orginalAktivitet, AktivitetData aktivitet) {
-        if (!Objects.equals(orginalAktivitet.getVersjon(), aktivitet.getVersjon())) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT);
-        } else if (skalIkkeKunneEndreAktivitetEtikett(orginalAktivitet)) {
-            throw new IllegalArgumentException(
-                    String.format("Kan ikke endre etikett på historisk aktivitet [%s]",
-                            orginalAktivitet.getId())
-            );
-        }
-    }
-
     private boolean skalIkkeKunneEndreAktivitet(AktivitetData aktivitetData) {
         AktivitetStatus status = aktivitetData.getStatus();
         return AktivitetStatus.AVBRUTT.equals(status)
                 || AktivitetStatus.FULLFORT.equals(status)
                 || aktivitetData.getHistoriskDato() != null
                 || aktivitetData.getAktivitetType() == AktivitetTypeData.STILLING_FRA_NAV;
-    }
-
-    private boolean skalIkkeKunneEndreAktivitetEtikett(AktivitetData aktivitetData) {
-        return aktivitetData.getHistoriskDato() != null;
     }
 
     @Transactional
@@ -194,7 +179,7 @@ public class AktivitetAppService {
     @Transactional
     public AktivitetData oppdaterEtikett(AktivitetData aktivitet) {
         val originalAktivitet = hentAktivitet(aktivitet.getId()); // innebærer tilgangskontroll
-        kanEndreAktivitetEtikettGuard(originalAktivitet, aktivitet);
+        kanEndreAktivitetGuard(originalAktivitet, aktivitet);
         return authService.getLoggedInnUser()
                 .map(userIdent -> {
                     aktivitetService.oppdaterEtikett(originalAktivitet, aktivitet, userIdent);

--- a/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AktivitetService.java
@@ -54,7 +54,7 @@ public class AktivitetService {
         return aktivitetDAO.hentAktivitetVersjoner(id);
     }
 
-    public long opprettAktivitet(Person.AktorId aktorId, AktivitetData aktivitet, Person endretAvPerson) {
+    public AktivitetData opprettAktivitet(Person.AktorId aktorId, AktivitetData aktivitet, Person endretAvPerson) {
         AktivitetData nyAktivivitet = aktivitet
                 .toBuilder()
                 .aktorId(aktorId.get())
@@ -69,7 +69,7 @@ public class AktivitetService {
         nyAktivivitet = aktivitetDAO.opprettNyAktivitet(kvpAktivivitet);
 
         metricService.opprettNyAktivitetMetrikk(aktivitet);
-        return nyAktivivitet.getId();
+        return nyAktivivitet;
     }
 
     @Transactional

--- a/src/main/java/no/nav/veilarbaktivitet/service/AuthService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AuthService.java
@@ -86,7 +86,7 @@ public class AuthService {
     }
 
     public boolean sjekKvpTilgang(String enhet) {
-        if (authContextHolder.erEksternBruker() || enhet == null || authContextHolder.erSystemBruker()) {
+        if (authContextHolder.erEksternBruker() || enhet == null) {
             return true;
         }
 

--- a/src/main/java/no/nav/veilarbaktivitet/service/AuthService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AuthService.java
@@ -86,7 +86,7 @@ public class AuthService {
     }
 
     public boolean sjekKvpTilgang(String enhet) {
-        if (authContextHolder.erEksternBruker() || enhet == null) {
+        if (authContextHolder.erEksternBruker() || enhet == null || authContextHolder.erSystemBruker()) {
             return true;
         }
 

--- a/src/main/java/no/nav/veilarbaktivitet/service/AuthService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/service/AuthService.java
@@ -149,10 +149,13 @@ public class AuthService {
         return authContextHolder.erInternBruker();
     }
 
+    public boolean erSystemBruker() {
+        return authContextHolder.erSystemBruker();
+    }
+
     public Optional<Person.AktorId> getAktorIdForEksternBruker() {
         return authContextHolder.erEksternBruker()
                 ? authContextHolder.getSubject().map(sub -> Person.aktorId(aktorOppslagClient.hentAktorId(Fnr.of(sub)).get()))
                 : Optional.empty();
     }
-
 }

--- a/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/OpprettForesporselOmDelingAvCv.java
+++ b/src/main/java/no/nav/veilarbaktivitet/stilling_fra_nav/OpprettForesporselOmDelingAvCv.java
@@ -62,14 +62,12 @@ public class OpprettForesporselOmDelingAvCv {
 
         Person.NavIdent navIdent = Person.navIdent(melding.getOpprettetAv());
 
-        long aktivitetId = aktivitetService.opprettAktivitet(aktorId, aktivitetData, navIdent);
-
-        AktivitetData aktivitetMedId = aktivitetData.withId(aktivitetId);
+        AktivitetData aktivitet = aktivitetService.opprettAktivitet(aktorId, aktivitetData, navIdent);
 
         if (erManuell || erReservertIKrr || !harBruktNivaa4) {
-            producerClient.sendOpprettetIkkeVarslet(aktivitetMedId, melding );
+            producerClient.sendOpprettetIkkeVarslet(aktivitet, melding );
         } else {
-            producerClient.sendOpprettet(aktivitetMedId, melding);
+            producerClient.sendOpprettet(aktivitet, melding);
         }
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/controller/AktivitetsplanRSTest.java
@@ -258,7 +258,7 @@ public class AktivitetsplanRSTest {
 
     private void gitt_at_jeg_har_folgende_aktiviteter(List<AktivitetData> aktiviteter) {
         lagredeAktivitetsIder = aktiviteter.stream()
-                .map(aktivitet -> aktivitetService.opprettAktivitet(KJENT_AKTOR_ID, aktivitet, KJENT_AKTOR_ID))
+                .map(aktivitet -> aktivitetService.opprettAktivitet(KJENT_AKTOR_ID, aktivitet, KJENT_AKTOR_ID).getId())
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/no/nav/veilarbaktivitet/service/AuthServiceTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/service/AuthServiceTest.java
@@ -64,4 +64,11 @@ class AuthServiceTest {
         assertEquals(eksternBruker, loggedInnUser.get());
     }
 
+    @Test
+    void erSystemBruker() {
+        when(authContextHolder.erSystemBruker()).thenReturn(Boolean.TRUE);
+        boolean erSystemBruker = authService.erSystemBruker();
+        assertEquals( Boolean.TRUE, erSystemBruker);
+    }
+
 }

--- a/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/OpprettForesporselOmDelingAvCvTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/stilling_fra_nav/OpprettForesporselOmDelingAvCvTest.java
@@ -3,12 +3,15 @@ package no.nav.veilarbaktivitet.stilling_fra_nav;
 import no.nav.veilarbaktivitet.avro.Arbeidssted;
 import no.nav.veilarbaktivitet.avro.DelingAvCvRespons;
 import no.nav.veilarbaktivitet.avro.ForesporselOmDelingAvCv;
+import no.nav.veilarbaktivitet.domain.AktivitetData;
+import no.nav.veilarbaktivitet.domain.AktivitetTypeData;
 import no.nav.veilarbaktivitet.domain.Person;
 import no.nav.veilarbaktivitet.kvp.KvpService;
 import no.nav.veilarbaktivitet.nivaa4.Nivaa4Client;
 import no.nav.veilarbaktivitet.oppfolging_status.OppfolgingStatusClient;
 import no.nav.veilarbaktivitet.oppfolging_status.OppfolgingStatusDTO;
 import no.nav.veilarbaktivitet.service.AktivitetService;
+import no.nav.veilarbaktivitet.testutils.AktivitetDataTestBuilder;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -34,7 +37,9 @@ public class OpprettForesporselOmDelingAvCvTest {
 
     public static final String BESTILLINGS_ID = "bestillingsId";
     public static final String AKTORID = "aktorid";
-    public static final long AKTIVITET_ID = 1L;
+    public static final AktivitetData AKTIVITET_DATA = AktivitetDataTestBuilder.nyAktivitet(AktivitetTypeData.MOTE);
+    public static final long AKTIVITET_ID = AKTIVITET_DATA.getId();
+
     @Mock
     private AktivitetService aktivitetService;
     @Mock
@@ -66,7 +71,7 @@ public class OpprettForesporselOmDelingAvCvTest {
         when(delingAvCvService.aktivitetAlleredeOpprettetForBestillingsId(BESTILLINGS_ID)).thenReturn(false);
         OppfolgingStatusDTO oppfolgingStatusDTO = OppfolgingStatusDTO.builder().underOppfolging(true).underKvp(false).manuell(false).reservasjonKRR(false).build();
         when(oppfolgingStatusClient.get(Person.aktorId(AKTORID))).thenReturn(Optional.of(oppfolgingStatusDTO));
-        when(aktivitetService.opprettAktivitet(any(), any(), any())).thenReturn(AKTIVITET_ID);
+        when(aktivitetService.opprettAktivitet(any(), any(), any())).thenReturn(AKTIVITET_DATA);
 
         opprettForesporselOmDelingAvCv.createAktivitet(melding);
 


### PR DESCRIPTION
https://trello.com/c/BcAVVflS

Dette er sannsynligvis resultat av en form for race-condition i prosessen med å registrere en bruker for oppfølging.
Nye registrerte brukere vil normalt ikke ha tilordnet en enhet, men siden hele prosessen kan ta litt tid, så er det i noen tilfeller at brukeren har blitt registrert for kvp før de automatiske aktivitetene opprettes. 
Dette fører til feil i veilarbaktivitet fordi vår tilgangskontroll ikke er tilpasset systembruker-kall. 
I tillegg har vi en feil i transaksjonshåndteringen som gjør at aktivitetene faktisk blir opprettet og lagret før det feiler.