### PR TITLE
Handle tokenx ekstern tokens

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/person/AuthService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/person/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
 
     public void sjekkEksternBrukerHarTilgang(Person ident) {
         var loggedInUserFnr = getInnloggetBrukerIdent();
-        if (!loggedInUserFnr.equals(ident.get())) {
+        if (!loggedInUserFnr.map(fnr -> fnr.equals(ident.get())).orElse(false)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                     "ekstern bruker har ikke tilgang til andre brukere enn seg selv"
             );

--- a/src/main/java/no/nav/veilarbaktivitet/person/AuthService.java
+++ b/src/main/java/no/nav/veilarbaktivitet/person/AuthService.java
@@ -55,9 +55,15 @@ public class AuthService {
                 }).orElse(false);
     }
 
+    private Person.Fnr getFnrForEksternBruker(Person ident) {
+        if (ident instanceof Person.Fnr) return (Person.Fnr) ident;
+        if (ident instanceof Person.AktorId) return personService.getFnrForAktorId(Person.aktorId(ident.get()));
+        throw new IllegalArgumentException("Kan ikke hente fnr for NAV-ansatte");
+    }
+
     public void sjekkTilgangTilPerson(Person ident) {
         if (erEksternBruker()) {
-            sjekkEksternBrukerHarTilgang(ident);
+            sjekkEksternBrukerHarTilgang(getFnrForEksternBruker(ident));
             return;
         }
 

--- a/src/test/java/no/nav/veilarbaktivitet/config/TestAuthContextFilter.java
+++ b/src/test/java/no/nav/veilarbaktivitet/config/TestAuthContextFilter.java
@@ -1,14 +1,18 @@
 package no.nav.veilarbaktivitet.config;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import no.nav.common.auth.context.AuthContext;
 import no.nav.common.auth.context.AuthContextHolderThreadLocal;
 import no.nav.common.auth.context.UserRole;
-import no.nav.common.test.auth.AuthTestUtils;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
+
+import static no.nav.common.test.auth.AuthTestUtils.TEST_AUDIENCE;
+import static no.nav.common.test.auth.AuthTestUtils.TEST_ISSUER;
 
 @Service
 public class TestAuthContextFilter implements Filter {
@@ -21,7 +25,15 @@ public class TestAuthContextFilter implements Filter {
         String test_ident = httpRequest.getHeader(identHeder);
         String test_ident_type = httpRequest.getHeader(typeHeder);
 
-        AuthContext authContext = AuthTestUtils.createAuthContext(UserRole.valueOf(test_ident_type), test_ident);
+        AuthContext authContext = new AuthContext(
+                UserRole.valueOf(test_ident_type),
+                new PlainJWT(new JWTClaimsSet.Builder()
+                        .subject(test_ident)
+                        .audience(TEST_AUDIENCE)
+                        .issuer(TEST_ISSUER)
+                        .claim("acr", "Level4")
+                        .build())
+        );
 
         AuthContextHolderThreadLocal.instance().withContext(authContext, () -> filterChain.doFilter(servletRequest, servletResponse));
     }

--- a/src/test/java/no/nav/veilarbaktivitet/service/AuthServiceTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/service/AuthServiceTest.java
@@ -102,4 +102,18 @@ class AuthServiceTest {
         });
     }
 
+    @Test
+    void skal_blokkere_ekstern_bruker_med_nivå3() {
+        when(authContextHolder.getUid()).thenReturn(Optional.of(FNR));
+        when(authContextHolder.getIdTokenClaims()).thenReturn(
+                Optional.ofNullable(new JWTClaimsSet.Builder()
+                        .claim(ID_PORTEN_PID_CLAIM, FNR)
+                        .claim("acr", "Level3")
+                        .build())
+        );
+        Assertions.assertThrows(ResponseStatusException.class, () -> {
+            authService.sjekkEksternBrukerHarTilgang(Person.fnr(FNR));
+        });
+    }
+
 }


### PR DESCRIPTION
Man kan ikke bruke tokenX tokens i ABAC, så dette må implementeres selv. POAO-frontend gir oss tokenX tokens så den oppgraderingen er avhengig av at vi støtter dette i alle våre backender som aktivitetplanen snakker med