### PR TITLE
Legg til versjon på migrerte arena-aktiviteter

### DIFF
--- a/src/main/java/no/nav/veilarbaktivitet/arena/model/ArenaAktivitetDTO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/arena/model/ArenaAktivitetDTO.java
@@ -27,6 +27,7 @@ public class ArenaAktivitetDTO {
     boolean avtalt;
     ForhaandsorienteringDTO forhaandsorientering;
     public ArenaStatusDTO etikett;
+    long aktivitetsVersjon;
 
     // Tiltaksaktivitet
     Float deltakelseProsent;

--- a/src/test/java/no/nav/veilarbaktivitet/arena/ArenaControllerTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/arena/ArenaControllerTest.java
@@ -66,14 +66,13 @@ class ArenaControllerTest {
     private final BrukernotifikasjonService brukernotifikasjonArenaAktivitetService = new BrukernotifikasjonService(personService, sistePeriodeService, notifikasjonArenaDAO, nivaa4Client, manuellStatusClient, aktivitetsplanBasepath, aktivitetDAO);
     private final ForhaandsorienteringDAO fhoDao = new ForhaandsorienteringDAO(db, db.getNamedJdbcTemplate());
     private final IdMappingDAO idMappingDAO = new IdMappingDAO(new NamedParameterJdbcTemplate(jdbc));
-
     private final UnleashClient unleashClient = mock(UnleashClient.class);
 
     private final MigreringService migreringService = new MigreringService(unleashClient, idMappingDAO);
 
     private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
     private final ArenaService arenaService = new ArenaService(fhoDao, meterRegistry, brukernotifikasjonArenaAktivitetService, veilarbarenaClient, idMappingDAO, personService);
-    private final ArenaController controller = new ArenaController(context, authService, arenaService, idMappingDAO, migreringService);
+    private final ArenaController controller = new ArenaController(context, authService, arenaService, idMappingDAO, aktivitetDAO, migreringService);
 
     private final Person.AktorId aktorid = Person.aktorId("12345678");
     private final Person.Fnr fnr = Person.fnr("987654321");


### PR DESCRIPTION
Trenger denne for å bruke /avtaltMedNav endepunkt istedetfor /forhaandsorientering (ArenaController) slik at det også går an å opprette forhaandsorientering på migrerte arena-aktiviteter hvis toggle er av. Trenger også endring i frontend som sjekker hvilken id som ligger på id feltet i ArenaAktivitetDTO-en, nå kan det enten være tekniskId (hvis migrert) eller arenaId (hvis ikke migrert)