### PR TITLE
Postgres18 forberedelser

### DIFF
--- a/.github/workflows/alerts-nye-dev.yml
+++ b/.github/workflows/alerts-nye-dev.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: deploy to dev-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/alerts-feilrate.yaml

--- a/.github/workflows/alerts-nye.yml
+++ b/.github/workflows/alerts-nye.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: deploy to dev-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/alerts-feilrate.yaml
       - name: deploy to prod-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-gcp
           RESOURCE: nais/alerts-feilrate.yaml

--- a/.github/workflows/alerts-slo.yml
+++ b/.github/workflows/alerts-slo.yml
@@ -36,12 +36,12 @@ jobs:
           path: alerts-feilrate-slo.yaml
 
       - name: deploy to dev-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-gcp
           RESOURCE:  alerts-feilrate-slo.yaml
       - name: deploy to prod-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-gcp
           RESOURCE: alerts-feilrate-slo.yaml

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
       - name: Execute Gradle build
         run: ./gradlew build --scan
       - name: Slack Notification (test failure)
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Deploy application to dev
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-dev-gcp.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Deploy application to prod
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-gcp
           RESOURCE: nais/nais-prod-gcp.yaml

--- a/.github/workflows/deploy_feature_branch_gcp.yml
+++ b/.github/workflows/deploy_feature_branch_gcp.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
       - name: Execute Gradle build
         run: ./gradlew assemble --scan
       - name: Push docker image to GAR
@@ -46,7 +46,7 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v7
         - name: Deploy
-          uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+          uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
           env:
             CLUSTER: dev-gcp
             RESOURCE: nais/nais-dev-gcp.yaml

--- a/.github/workflows/kafka-topic-dev.yaml
+++ b/.github/workflows/kafka-topic-dev.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: List resource files
         run: echo "RESOURCE_FILES=$(find kafka-topic/dev -type f | tr '\n' ',' | sed 's/,$/\n/')" >> $GITHUB_ENV
       - name: Deploy kafka topics
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-gcp
           RESOURCE: ${{ env.RESOURCE_FILES }}

--- a/.github/workflows/kafka-topic-prod.yaml
+++ b/.github/workflows/kafka-topic-prod.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: List resource files
         run: echo "RESOURCE_FILES=$(find kafka-topic/prod -type f | tr '\n' ',' | sed 's/,$/\n/')" >> $GITHUB_ENV
       - name: Deploy kafka topics
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-gcp
           RESOURCE: ${{ env.RESOURCE_FILES }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -23,6 +23,6 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
       - name: Test and build
         run: ./gradlew test build

--- a/.github/workflows/testMedSonar.yml
+++ b/.github/workflows/testMedSonar.yml
@@ -22,10 +22,10 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/unleash-apitoken.yaml
+++ b/.github/workflows/unleash-apitoken.yaml
@@ -21,22 +21,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: deploy to dev
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-fss
           RESOURCE: nais/unleash-apitoken-dev.yaml
       - name: deploy to prod
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-fss
           RESOURCE: nais/unleash-apitoken.yaml
       - name: deploy to dev-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/unleash-apitoken-dev-gcp.yaml
       - name: deploy to prod-gcp
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-gcp
           RESOURCE: nais/unleash-apitoken-gcp.yaml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 val spring_boot_version = "4.1.0"
-val tomcat_version = "11.0.22"
+val tomcat_version = "11.0.23"
 
 extra["tomcat.version"] = tomcat_version
-val common_version = "4.2026.06.24_08.27-d324901a85d7"
+val common_version = "4.2026.06.25_10.50-baa9d54e3cd8"
 val dab_common_version = "2026.05.11-16.10.4d6c1e3c3451"
 val poao_tilgang_version = "4.2026.06.22_05.28-bc567ee327c9"
 val shedlock_version = "7.7.0"
 val avroVersion = "1.12.1"
 val confluentKafkaAvroVersion = "8.2.0"
 val okhttpVersion = "5.4.0"
-val logback_version = "1.5.34"
+val logback_version = "1.5.36"
 val log4j_version = "2.26.0"
 val _version: String by project
 
@@ -204,7 +204,7 @@ dependencies {
 //test dependencies
     testImplementation("no.nav.poao-tilgang:poao-tilgang-test-wiremock:$poao_tilgang_version")
     testImplementation("org.awaitility:awaitility:4.3.0")
-    testImplementation("com.networknt:json-schema-validator:3.0.4")
+    testImplementation("com.networknt:json-schema-validator:3.0.5")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
     testImplementation("io.rest-assured:rest-assured:6.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -215,5 +215,6 @@ dependencies {
     testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("org.mockito:mockito-core")
     testImplementation("io.zonky.test:embedded-database-spring-test:2.8.0")
+    testImplementation(platform("io.zonky.test.postgres:embedded-postgres-binaries-bom:18.4.0"))
     testImplementation("io.zonky.test:embedded-postgres:2.2.2")
 }

--- a/src/main/java/no/nav/veilarbaktivitet/brukernotifikasjon/avslutt/AvsluttDao.java
+++ b/src/main/java/no/nav/veilarbaktivitet/brukernotifikasjon/avslutt/AvsluttDao.java
@@ -27,6 +27,7 @@ public class AvsluttDao {
                         " SELECT BRUKERNOTIFIKASJON_ID, FOEDSELSNUMMER, OPPFOLGINGSPERIODE" +
                         " from BRUKERNOTIFIKASJON B" +
                         " where STATUS = :status" +
+                        " order by B.ID" +
                         " fetch first :limit rows only",
                 param,
                 skalAvsluttesMapper);

--- a/src/main/java/no/nav/veilarbaktivitet/brukernotifikasjon/kvittering/KvitteringDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/brukernotifikasjon/kvittering/KvitteringDAO.java
@@ -89,6 +89,7 @@ public class KvitteringDAO {
                          WHERE FERDIG_BEHANDLET IS NULL
                          AND VARSEL_KVITTERING_STATUS = 'OK'
                          AND TYPE = :type
+                         ORDER BY id
                          FETCH FIRST :limit ROWS ONLY
                         """, parameterSource, rowmapper);
     }
@@ -104,6 +105,7 @@ public class KvitteringDAO {
                  WHERE FERDIG_BEHANDLET IS NULL
                  AND VARSEL_KVITTERING_STATUS = 'FEILET'
                  AND TYPE = :type
+                 ORDER BY id
                  FETCH FIRST :limit ROWS ONLY
                 """, parameterSource, rowmapper);
     }

--- a/src/main/java/no/nav/veilarbaktivitet/brukernotifikasjon/varsel/VarselDAO.java
+++ b/src/main/java/no/nav/veilarbaktivitet/brukernotifikasjon/varsel/VarselDAO.java
@@ -82,6 +82,7 @@ public class VarselDAO {
                                  WHERE
                                      B.STATUS = 'PENDING' AND
                                      A.AKTIVITET_ID IS NULL
+                                 ORDER BY B.ID
                                  LIMIT :limit;
                                 """,
                         parameterSource, rowMapper);

--- a/src/main/java/no/nav/veilarbaktivitet/config/database/Database.java
+++ b/src/main/java/no/nav/veilarbaktivitet/config/database/Database.java
@@ -48,10 +48,6 @@ public class Database {
         return jdbcTemplate.queryForObject(sql, cls);
     }
 
-    public long nesteFraSekvens(String sekvensNavn) {
-        return jdbcTemplate.queryForObject("select " + sekvensNavn + ".nextval from dual", Long.class);
-    }
-
     public static Date hentDato(ResultSet rs, String kolonneNavn) throws SQLException {
         return ofNullable(rs.getTimestamp(kolonneNavn))
                 .map(Timestamp::getTime)

--- a/src/test/java/no/nav/veilarbaktivitet/db/ViewTest.java
+++ b/src/test/java/no/nav/veilarbaktivitet/db/ViewTest.java
@@ -81,7 +81,8 @@ class ViewTest {
                 "DATA_TYPE, " +
                 "CHARACTER_MAXIMUM_LENGTH " +
                 "FROM INFORMATION_SCHEMA.COLUMNS " +
-                "WHERE TABLE_NAME = '" + view.toLowerCase() + "';"
+                "WHERE TABLE_NAME = '" + view.toLowerCase() + "' " +
+                "ORDER BY COLUMN_NAME;"
         );
     }
 

--- a/src/test/resources/view-meta-data/dvh_akt_livslopstatus_type.json
+++ b/src/test/resources/view-meta-data/dvh_akt_livslopstatus_type.json
@@ -1,7 +1,12 @@
 [
   {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
+    "column_name": "aktivitet_livslop_kode",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "endret_av",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -10,18 +15,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "aktivitet_livslop_kode",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
     "column_name": "opprettet_av",
     "data_type": "character varying",
     "character_maximum_length": null
   },
   {
-    "column_name": "endret_av",
-    "data_type": "character varying",
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_aktivitet.json
+++ b/src/test/resources/view-meta-data/dvh_aktivitet.json
@@ -5,67 +5,7 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "versjon",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "fra_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "til_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "endret_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "avtalt_flagg",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "historisk_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "gjeldende_flagg",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "automatisk_opprettet",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "lenke",
-    "data_type": "text",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "beskrivelse",
-    "data_type": "text",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "oppfolgingsperiode_uuid",
-    "data_type": "character varying",
-    "character_maximum_length": 40
-  },
-  {
-    "column_name": "transaksjons_type",
+    "column_name": "aktivitet_type_kode",
     "data_type": "character varying",
     "character_maximum_length": null
   },
@@ -75,13 +15,8 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "tittel",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "aktivitet_type_kode",
-    "data_type": "character varying",
+    "column_name": "automatisk_opprettet",
+    "data_type": "numeric",
     "character_maximum_length": null
   },
   {
@@ -90,8 +25,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "lagt_inn_av",
-    "data_type": "character varying",
+    "column_name": "avtalt_flagg",
+    "data_type": "numeric",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "beskrivelse",
+    "data_type": "text",
     "character_maximum_length": null
   },
   {
@@ -100,8 +40,68 @@
     "character_maximum_length": null
   },
   {
+    "column_name": "endret_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "fra_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "gjeldende_flagg",
+    "data_type": "numeric",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "historisk_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "lagt_inn_av",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "lenke",
+    "data_type": "text",
+    "character_maximum_length": null
+  },
+  {
     "column_name": "livslopstatus_kode",
     "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "oppfolgingsperiode_uuid",
+    "data_type": "character varying",
+    "character_maximum_length": 40
+  },
+  {
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "til_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "tittel",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "transaksjons_type",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_aktivitet_type.json
+++ b/src/test/resources/view-meta-data/dvh_aktivitet_type.json
@@ -1,7 +1,12 @@
 [
   {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
+    "column_name": "aktivitet_type_kode",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "endret_av",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -10,18 +15,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "aktivitet_type_kode",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
     "column_name": "opprettet_av",
     "data_type": "character varying",
     "character_maximum_length": null
   },
   {
-    "column_name": "endret_av",
-    "data_type": "character varying",
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_egenaktivitet.json
+++ b/src/test/resources/view-meta-data/dvh_egenaktivitet.json
@@ -5,11 +5,6 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "versjon",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
     "column_name": "endret_dato",
     "data_type": "timestamp without time zone",
     "character_maximum_length": null
@@ -22,6 +17,11 @@
   {
     "column_name": "oppfolging",
     "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_ijobb.json
+++ b/src/test/resources/view-meta-data/dvh_ijobb.json
@@ -5,8 +5,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "versjon",
-    "data_type": "numeric",
+    "column_name": "ansettelsesforhold",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "arbeidstid",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -15,13 +20,8 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "ansettelsesforhold",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "arbeidstid",
-    "data_type": "character varying",
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_jobb_status_type.json
+++ b/src/test/resources/view-meta-data/dvh_jobb_status_type.json
@@ -1,7 +1,7 @@
 [
   {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
+    "column_name": "endret_av",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -20,8 +20,8 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "endret_av",
-    "data_type": "character varying",
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_kanal_type.json
+++ b/src/test/resources/view-meta-data/dvh_kanal_type.json
@@ -1,7 +1,7 @@
 [
   {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
+    "column_name": "endret_av",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -20,8 +20,8 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "endret_av",
-    "data_type": "character varying",
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_mote.json
+++ b/src/test/resources/view-meta-data/dvh_mote.json
@@ -1,7 +1,7 @@
 [
   {
-    "column_name": "versjon",
-    "data_type": "numeric",
+    "column_name": "adresse",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -10,8 +10,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "referat_publisert",
-    "data_type": "numeric",
+    "column_name": "forberedelser",
+    "data_type": "text",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "kanal",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -20,18 +25,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "forberedelser",
-    "data_type": "text",
+    "column_name": "referat_publisert",
+    "data_type": "numeric",
     "character_maximum_length": null
   },
   {
-    "column_name": "adresse",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "kanal",
-    "data_type": "character varying",
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_sokeavtale_aktivitet.json
+++ b/src/test/resources/view-meta-data/dvh_sokeavtale_aktivitet.json
@@ -5,13 +5,13 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "versjon",
+    "column_name": "antall_stillinger_sokes",
     "data_type": "numeric",
     "character_maximum_length": null
   },
   {
-    "column_name": "antall_stillinger_sokes",
-    "data_type": "numeric",
+    "column_name": "avtale_oppfolging",
+    "data_type": "text",
     "character_maximum_length": null
   },
   {
@@ -20,8 +20,8 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "avtale_oppfolging",
-    "data_type": "text",
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_stilling_fra_nav_aktivitet.json
+++ b/src/test/resources/view-meta-data/dvh_stilling_fra_nav_aktivitet.json
@@ -1,36 +1,11 @@
 [
   {
-    "column_name": "cv_kan_deles",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "cv_kan_deles_tidspunkt",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "svarfrist",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "versjon",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "cv_kan_deles_avtalt_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
     "column_name": "aktivitet_id",
     "data_type": "numeric",
     "character_maximum_length": null
   },
   {
-    "column_name": "stillingsid",
+    "column_name": "arbeidsgiver",
     "data_type": "character varying",
     "character_maximum_length": 255
   },
@@ -40,7 +15,37 @@
     "character_maximum_length": 255
   },
   {
-    "column_name": "varselid",
+    "column_name": "bestillingsid",
+    "data_type": "character varying",
+    "character_maximum_length": 255
+  },
+  {
+    "column_name": "cv_kan_deles",
+    "data_type": "numeric",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "cv_kan_deles_av",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "cv_kan_deles_av_type",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "cv_kan_deles_avtalt_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "cv_kan_deles_tidspunkt",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "kontaktperson_mobil",
     "data_type": "character varying",
     "character_maximum_length": 255
   },
@@ -55,7 +60,12 @@
     "character_maximum_length": 255
   },
   {
-    "column_name": "kontaktperson_mobil",
+    "column_name": "livslopsstatus",
+    "data_type": "character varying",
+    "character_maximum_length": 255
+  },
+  {
+    "column_name": "soknadsfrist",
     "data_type": "character varying",
     "character_maximum_length": 255
   },
@@ -65,33 +75,23 @@
     "character_maximum_length": 255
   },
   {
-    "column_name": "livslopsstatus",
+    "column_name": "stillingsid",
     "data_type": "character varying",
     "character_maximum_length": 255
   },
   {
-    "column_name": "cv_kan_deles_av",
-    "data_type": "character varying",
+    "column_name": "svarfrist",
+    "data_type": "timestamp without time zone",
     "character_maximum_length": null
   },
   {
-    "column_name": "cv_kan_deles_av_type",
+    "column_name": "varselid",
     "data_type": "character varying",
+    "character_maximum_length": 255
+  },
+  {
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
-  },
-  {
-    "column_name": "soknadsfrist",
-    "data_type": "character varying",
-    "character_maximum_length": 255
-  },
-  {
-    "column_name": "arbeidsgiver",
-    "data_type": "character varying",
-    "character_maximum_length": 255
-  },
-  {
-    "column_name": "bestillingsid",
-    "data_type": "character varying",
-    "character_maximum_length": 255
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_stillingsok_aktivitet.json
+++ b/src/test/resources/view-meta-data/dvh_stillingsok_aktivitet.json
@@ -5,27 +5,7 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "versjon",
-    "data_type": "numeric",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "endret_dato",
-    "data_type": "timestamp without time zone",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "stillingstittel",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "kontaktperson",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
-    "column_name": "etikett",
+    "column_name": "arbeidsgiver",
     "data_type": "character varying",
     "character_maximum_length": null
   },
@@ -35,8 +15,28 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "arbeidsgiver",
+    "column_name": "endret_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "etikett",
     "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "kontaktperson",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "stillingstittel",
+    "data_type": "character varying",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "versjon",
+    "data_type": "numeric",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_stillingsok_etikett_type.json
+++ b/src/test/resources/view-meta-data/dvh_stillingsok_etikett_type.json
@@ -1,7 +1,7 @@
 [
   {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
+    "column_name": "endret_av",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -20,8 +20,8 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "endret_av",
-    "data_type": "character varying",
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
     "character_maximum_length": null
   }
 ]

--- a/src/test/resources/view-meta-data/dvh_transaksjon_type.json
+++ b/src/test/resources/view-meta-data/dvh_transaksjon_type.json
@@ -1,7 +1,7 @@
 [
   {
-    "column_name": "opprettet_dato",
-    "data_type": "timestamp without time zone",
+    "column_name": "endret_av",
+    "data_type": "character varying",
     "character_maximum_length": null
   },
   {
@@ -10,17 +10,17 @@
     "character_maximum_length": null
   },
   {
-    "column_name": "transaksjons_type_kode",
-    "data_type": "character varying",
-    "character_maximum_length": null
-  },
-  {
     "column_name": "opprettet_av",
     "data_type": "character varying",
     "character_maximum_length": null
   },
   {
-    "column_name": "endret_av",
+    "column_name": "opprettet_dato",
+    "data_type": "timestamp without time zone",
+    "character_maximum_length": null
+  },
+  {
+    "column_name": "transaksjons_type_kode",
     "data_type": "character varying",
     "character_maximum_length": null
   }


### PR DESCRIPTION
- Oppdaterer diverse avhengigheter
- Bruker postgres 18 for testene
- I postgres 18 kan rekkefølgen på elementene man får ut fra en select være annerledes. Har derfor lagt på en order by på flere av spørringene som henter flere elementer for å få deterministisk oppførsel. 
- Av samme grunn er view-json-filene oppdatert slik at elementene er sortert etter kolonnenavn

https://trello.com/c/yNvmDGJF/1575-oppgradere-databaser-som-er-p%C3%A5-versjon-14